### PR TITLE
fix caption window would cover app window content

### DIFF
--- a/core/java/android/view/View.java
+++ b/core/java/android/view/View.java
@@ -87,6 +87,7 @@ import android.content.res.CompatibilityInfo;
 import android.content.res.Configuration;
 import android.content.res.Resources;
 import android.content.res.TypedArray;
+import android.content.SharedPreferences;
 import android.credentials.CredentialManager;
 import android.credentials.CredentialOption;
 import android.credentials.GetCredentialException;
@@ -5677,6 +5678,8 @@ public class View implements Drawable.Callback, KeyEvent.Callback,
     @FlaggedApi(FLAG_TOOLKIT_SET_FRAME_RATE_READ_ONLY)
     public static final float REQUESTED_FRAME_RATE_CATEGORY_HIGH = -4;
 
+    private SharedPreferences mSharedPreferences = null;
+
     /**
      * Simple constructor to use when creating a view from code.
      *
@@ -5763,6 +5766,14 @@ public class View implements Drawable.Callback, KeyEvent.Callback,
             sForceLayoutWhenInsetsChanged = targetSdkVersion < Build.VERSION_CODES.R;
 
             sCompatibilityDone = true;
+        }
+
+        try {
+            if (mContext != null) {
+                mSharedPreferences = mContext.getSharedPreferences("MyPrefs", Context.MODE_PRIVATE);
+            }
+        } catch(Exception e) {
+            Log.e(VIEW_LOG_TAG, "fde getSharedPreferences error: " + e);
         }
     }
 
@@ -13249,8 +13260,26 @@ public class View implements Drawable.Callback, KeyEvent.Callback,
      * @return Insets that should be passed along to views under this one
      */
     public WindowInsets computeSystemWindowInsets(WindowInsets in, Rect outLocalInsets) {
+
+        // [openfde add] fix caption window would cover app window content
+        boolean isTurnOnFullScreen = false;
+        if (mSharedPreferences == null) {
+            try {
+                if (mContext != null) {
+                    mSharedPreferences = mContext.getSharedPreferences("MyPrefs", Context.MODE_PRIVATE);
+                }
+            } catch(Exception e) {
+                Log.e(VIEW_LOG_TAG, "fde getSharedPreferences error: " + e);
+            }
+        }
+        if (mSharedPreferences != null) {
+            isTurnOnFullScreen = mSharedPreferences.getBoolean("mTurnOnFullScreen", false);
+        }
+        // [openfde end]
+
         boolean isOptionalFitSystemWindows = (mViewFlags & OPTIONAL_FITS_SYSTEM_WINDOWS) != 0
-                || (mPrivateFlags4 & PFLAG4_FRAMEWORK_OPTIONAL_FITS_SYSTEM_WINDOWS) != 0;
+                || (mPrivateFlags4 & PFLAG4_FRAMEWORK_OPTIONAL_FITS_SYSTEM_WINDOWS) != 0
+                || isTurnOnFullScreen;
         if (isOptionalFitSystemWindows && mAttachInfo != null) {
             OnContentApplyWindowInsetsListener listener =
                     mAttachInfo.mContentOnApplyWindowInsetsListener;

--- a/core/java/com/android/internal/policy/PhoneWindow.java
+++ b/core/java/com/android/internal/policy/PhoneWindow.java
@@ -34,6 +34,7 @@ import static android.view.WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_M
 import static android.view.WindowManager.LayoutParams.PRIVATE_FLAG_EDGE_TO_EDGE_ENFORCED;
 import static android.view.WindowManager.LayoutParams.PRIVATE_FLAG_FORCE_DRAW_BAR_BACKGROUNDS;
 import static android.view.WindowManager.LayoutParams.PRIVATE_FLAG_NO_MOVE_ANIMATION;
+import static android.view.WindowManager.LayoutParams.COMPATIBLE_FLAG_SHIFT_CONTENT_BELOW_CAPTION;
 
 import android.annotation.NonNull;
 import android.annotation.Nullable;
@@ -2834,8 +2835,18 @@ public class PhoneWindow extends Window implements MenuBuilder.Callback {
         if (mContentParent == null) {
             mContentParent = generateLayout(mDecor);
 
-            // Set up decor part of UI to ignore fitsSystemWindows if appropriate.
-            mDecor.makeFrameworkOptionalFitsSystemWindows();
+            // [openfde add] fix caption window would cover app window content
+            WindowManager.LayoutParams params = getAttributes();
+            int features = getLocalFeatures();
+            if (((params.flags & FLAG_FULLSCREEN) != 0
+                        && (features & (1 << FEATURE_NO_TITLE)) != 0
+                        && (features & (1 << FEATURE_CUSTOM_TITLE)) != 0)
+                    || (params.compatibleFlags & COMPATIBLE_FLAG_SHIFT_CONTENT_BELOW_CAPTION) != 0
+                    || getContext().getPackageName().contains("com.android.launcher3")) {
+                // Set up decor part of UI to ignore fitsSystemWindows if appropriate.
+                mDecor.makeFrameworkOptionalFitsSystemWindows();
+            }
+            // [openfde end]
 
             final DecorContentParent decorContentParent = (DecorContentParent) mDecor.findViewById(
                     R.id.decor_content_parent);


### PR DESCRIPTION
解决标题栏遮挡部分应用窗口内容
1.对于申请了自定义标题栏的应用窗口，还是继续调用makeFrameworkOptionalFitsSystemWindows方法，忽略系统自动适配窗口位置
2.对于配置了兼容性属性（isShiftContentBelowCaption），也会忽略系统自动适配窗口位置
3.全屏显示时，需要忽略系统自动适配窗口位置，否则会出现全屏下的导航栏显示黑屏的问题