### PR TITLE
fix x11-windows and captionbar are not synchronized during window scaling

### DIFF
--- a/core/java/android/view/SurfaceControl.java
+++ b/core/java/android/view/SurfaceControl.java
@@ -1425,7 +1425,7 @@ public final class SurfaceControl implements Parcelable {
      * Returns the name of this SurfaceControl, mainly for debugging purposes.
      * @hide
      */
-    @NonNull String getName() {
+    public @NonNull String getName() {
         return mName;
     }
 

--- a/libs/WindowManager/Shell/src/com/android/wm/shell/windowdecor/WindowDecoration.java
+++ b/libs/WindowManager/Shell/src/com/android/wm/shell/windowdecor/WindowDecoration.java
@@ -310,10 +310,16 @@ public abstract class WindowDecoration<T extends View & TaskFocusStateConsumer>
             String mCaptionContainerSurfaceName = "Caption of Task=" + mTaskInfo.taskId;
             SystemProperties.set("com.fde.top_package_name", mTaskInfo.topActivity.getPackageName());
             SystemProperties.set("com.fde.caption_name", mCaptionContainerSurfaceName);
+            SystemProperties.set("com.fde.task_name", mTaskSurface.getName());
 
             String mPackageNameWithCaption = SystemProperties.get("com.fde.package_with_caption", "");
+            /**
+             * when app is mutli-window app,  the prop would get app package name.
+             * when app is single-window app, the prop would get app class name.
+             **/
             if (mPackageNameWithCaption != "" &&
-                    mTaskInfo.topActivity.getPackageName().contains(mPackageNameWithCaption)) {
+                    (mTaskInfo.topActivity.getPackageName().contains(mPackageNameWithCaption)
+                        || mPackageNameWithCaption.contains(mTaskInfo.topActivity.getClassName()))) {
                 mNewCaptionWidth = SystemProperties.getInt("com.fde.caption_width", 0);
             }
         }


### PR DESCRIPTION
解决X11 Linux应用窗口与标题栏宽度不一致的问题，解决缩放过程中标题栏宽度出现抖动的问题
解决方案：
1.增加应用窗口是否与标题栏窗口在同一个父布局的判断逻辑，如果当前窗口与标题栏处于同一个父窗口下，则计算该窗口的宽度，否则丢弃，防止一个应用启动多个窗口导致窗口宽度重复计算的问题
2.优化标题栏宽度同步的时机，更新prop属性提前到应用窗口Bounds设置时，防止shell进程获取的captionbar宽度数据过旧导致的抖动问题

依赖提交：https://github.com/openfde/lineageos_android_frameworks_native/pull/5