### PR TITLE
feat(magic-window): implement dual-task magic window with concurrent …

### DIFF
--- a/core/java/android/app/ApplicationPackageManager.java
+++ b/core/java/android/app/ApplicationPackageManager.java
@@ -780,6 +780,10 @@ public class ApplicationPackageManager extends PackageManager {
 
     @Override
     public boolean hasSystemFeature(String name) {
+        // Log.w(TAG, "hasSystemFeature:" + name);
+        if("oplus.hardware.type.tablet".equals(name)){
+            return true;
+        }
         return hasSystemFeature(name, 0);
     }
 

--- a/core/java/android/app/Instrumentation.java
+++ b/core/java/android/app/Instrumentation.java
@@ -62,6 +62,8 @@ import android.view.Window;
 import android.view.WindowManagerGlobal;
 
 import com.android.internal.content.ReferrerIntent;
+import com.android.internal.util.CompatibleConfig;
+import android.text.TextUtils;
 
 import java.io.File;
 import java.lang.annotation.Retention;
@@ -1997,6 +1999,7 @@ public class Instrumentation {
         try {
             intent.migrateExtraStreamToClipData(who);
             intent.prepareToLeaveProcess(who);
+            boolean isMagic = getMagicExtra(intent, who);
             int result = ActivityTaskManager.getService().startActivity(whoThread,
                     who.getOpPackageName(), who.getAttributionTag(), intent,
                     intent.resolveTypeIfNeeded(who.getContentResolver()), token,
@@ -2008,6 +2011,31 @@ public class Instrumentation {
         }
         return null;
     }
+
+    // fde start MAGIC WINDOW
+
+    /**
+     *  if the packageName is magic window package, add extra fde_magic_window
+     * @param intent
+     * @param who
+     * @return
+     */
+    private boolean getMagicExtra(Intent intent, Context who){
+        if(intent != null && intent.getComponent() != null && intent.getComponent().getPackageName() != null){
+            String packageName =  intent.getComponent().getPackageName();
+            String selection = "PACKAGE_NAME = ? AND KEY_CODE = ? AND ACTIVITY_NAME = ?";
+            String[] selectionArgsWithoutActivity = {packageName,"enableMagicWindow", ""};
+            String resultStrWithoutActivity = CompatibleConfig.queryStringValueData(who, selection, selectionArgsWithoutActivity);
+            Log.d(TAG,"enableMagicWindow resultStrWithoutActivity: " + resultStrWithoutActivity);
+            if(TextUtils.equals(resultStrWithoutActivity, "true")){
+                Log.d(TAG,  "put extra fde_magic_window true");
+                intent.setExtraFDE(resultStrWithoutActivity);
+                return true;
+            }
+        }
+        return false;
+    }
+    // fde end
 
     /**
      * Like {@link #execStartActivity(Context, IBinder, IBinder, Activity, Intent, int, Bundle)},
@@ -2089,6 +2117,7 @@ public class Instrumentation {
                 intents[i].migrateExtraStreamToClipData(who);
                 intents[i].prepareToLeaveProcess(who);
                 resolvedTypes[i] = intents[i].resolveTypeIfNeeded(who.getContentResolver());
+                boolean isMagic =  getMagicExtra(intents[i], who);
             }
             int result = ActivityTaskManager.getService().startActivities(whoThread,
                     who.getOpPackageName(), who.getAttributionTag(), intents, resolvedTypes,

--- a/core/java/android/app/TaskInfo.java
+++ b/core/java/android/app/TaskInfo.java
@@ -105,6 +105,12 @@ public class TaskInfo {
     public ComponentName realActivity;
 
     /**
+     * magic windowing type of this task.
+     * @hide
+     */
+    public int magicWindowType = 0;
+
+    /**
      * The number of activities in this task (including running).
      */
     public int numActivities;
@@ -493,6 +499,7 @@ public class TaskInfo {
         displayAreaFeatureId = source.readInt();
         isTopActivityTransparent = source.readBoolean();
         appCompatTaskInfo = source.readTypedObject(AppCompatTaskInfo.CREATOR);
+        magicWindowType = source.readInt();
     }
 
     /**
@@ -540,6 +547,7 @@ public class TaskInfo {
         dest.writeInt(displayAreaFeatureId);
         dest.writeBoolean(isTopActivityTransparent);
         dest.writeTypedObject(appCompatTaskInfo, flags);
+        dest.writeInt(magicWindowType);
     }
 
     @Override
@@ -577,6 +585,7 @@ public class TaskInfo {
                 + " displayAreaFeatureId=" + displayAreaFeatureId
                 + " isTopActivityTransparent=" + isTopActivityTransparent
                 + " appCompatTaskInfo=" + appCompatTaskInfo
+                + " magicWindowType=" + magicWindowType
                 + "}";
     }
 }

--- a/core/java/android/content/Intent.java
+++ b/core/java/android/content/Intent.java
@@ -7806,6 +7806,7 @@ public class Intent implements Parcelable, Cloneable {
     /** Token to track instant app launches. Local only; do not copy cross-process. */
     private String mLaunchToken;
     private Intent mOriginalIntent; // Used for the experimental "component alias" feature.
+    private String extraFDE;
 
     // ---------------------------------------------------------------------
 
@@ -9897,6 +9898,20 @@ public class Intent implements Parcelable, Cloneable {
     public @Flags int getFlags() {
         return mFlags;
     }
+
+    // fde start MAGIC WINDOW
+    /** @hide */
+    @UnsupportedAppUsage
+    public void setExtraFDE(String extra) {
+        this.extraFDE = extra;
+    }
+
+    /** @hide */
+    @UnsupportedAppUsage
+    public String getExtraFDE() {
+        return extraFDE;
+    }
+    // fde end
 
     /**
      * Retrieve any extended flags associated with this intent.  You will
@@ -12195,6 +12210,7 @@ public class Intent implements Parcelable, Cloneable {
         }
         out.writeInt(mContentUserHint);
         out.writeBundle(mExtras);
+        out.writeString8(extraFDE);
 
         if (mOriginalIntent != null) {
             out.writeInt(1);
@@ -12256,6 +12272,7 @@ public class Intent implements Parcelable, Cloneable {
         }
         mContentUserHint = in.readInt();
         mExtras = in.readBundle();
+        extraFDE = in.readString8();
         if (in.readInt() != 0) {
             mOriginalIntent = new Intent(in);
         }

--- a/core/res/res/raw/comp_config_value.xml
+++ b/core/res/res/raw/comp_config_value.xml
@@ -199,4 +199,45 @@
             <activity name="QRActivity">true</activity>
         </package>
     </item>
+
+
+
+    <item
+        isdel="false"
+        key_code="enableMagicWindow"
+        update_date="2025-12-3">
+        <package name="com.jingdong.app.mall">
+            <activity name="">true</activity>
+        </package>
+        <package name="com.ss.android.article.news">
+            <activity name="">true</activity>
+        </package>
+        <package name="com.zhihu.android">
+            <activity name="">true</activity>
+        </package>
+        <package name="com.xingin.xhs">
+            <activity name="">true</activity>
+        </package>
+        <package name="com.sina.weibo">
+            <activity name="">true</activity>
+        </package>
+        <package name="com.kuaishou.nebula">
+            <activity name="">true</activity>
+        </package>
+        <package name="ctrip.android.view">
+            <activity name="">true</activity>
+        </package>
+        <package name="com.Qunar">
+            <activity name="">true</activity>
+        </package>
+        <package name="com.tencent.mm">
+            <activity name="">true</activity>
+        </package>
+        <package name="com.lite.ceclanxin">
+            <activity name="">true</activity>
+        </package>
+
+    </item>
+
+
 </items>

--- a/libs/WindowManager/Shell/src/com/android/wm/shell/ShellTaskOrganizer.java
+++ b/libs/WindowManager/Shell/src/com/android/wm/shell/ShellTaskOrganizer.java
@@ -643,6 +643,21 @@ public class ShellTaskOrganizer extends TaskOrganizer implements
         }
     }
 
+    public RunningTaskInfo getRunningTaskInfo(int taskId, String packageName, int type){
+        if(type == 0){
+            return null;
+        }
+        for (int i = 0; i < mTasks.size(); i++) {
+            RunningTaskInfo taskInfo = mTasks.valueAt(i).getTaskInfo();
+            if (taskInfo.taskId != taskId && taskInfo.topActivity != null
+                    &&  taskInfo.topActivity.getPackageName().equals(packageName)
+                    &&  taskInfo.magicWindowType != type && taskInfo.magicWindowType != 0) {
+                return taskInfo;
+            }
+        }
+        return null;
+    }
+
     private boolean updateTaskListenerIfNeeded(RunningTaskInfo taskInfo, SurfaceControl leash,
             TaskListener oldListener, TaskListener newListener) {
         if (oldListener == newListener) return false;

--- a/libs/WindowManager/Shell/src/com/android/wm/shell/windowdecor/CaptionWindowDecorViewModel.java
+++ b/libs/WindowManager/Shell/src/com/android/wm/shell/windowdecor/CaptionWindowDecorViewModel.java
@@ -337,7 +337,7 @@ public class CaptionWindowDecorViewModel implements WindowDecorViewModel {
 
         final FluidResizeTaskPositioner taskPositioner =
                 new FluidResizeTaskPositioner(mTaskOrganizer, mTransitions, windowDecoration,
-                        mDisplayController, 0 /* disallowedAreaForEndBoundsHeight */);
+                        mDisplayController, 0 /* disallowedAreaForEndBoundsHeight */, mTaskOperations, mWindowDecorByTaskId);
         final CaptionTouchEventListener touchEventListener =
                 new CaptionTouchEventListener(taskInfo, taskPositioner);
         windowDecoration.setCaptionListeners(touchEventListener, touchEventListener);
@@ -388,6 +388,14 @@ public class CaptionWindowDecorViewModel implements WindowDecorViewModel {
             final int id = v.getId();
             if (id == R.id.close_window) {
                 mTaskOperations.closeTask(mTaskToken);
+                RunningTaskInfo taskInfo = mTaskOrganizer.getRunningTaskInfo(mTaskId);
+                if( taskInfo.topActivity != null && taskInfo.magicWindowType == 1){
+                    RunningTaskInfo magicTaskInfo = mTaskOrganizer.getRunningTaskInfo(mTaskId,
+                            taskInfo.topActivity.getPackageName(), taskInfo.magicWindowType);
+                    if(magicTaskInfo != null){
+                        mTaskOperations.closeTask(magicTaskInfo.token);
+                    }
+                }
             } else if (id == R.id.back_button) {
                 Log.d(TAG, "onClick back_button");
                 mTaskOperations.injectBackKey(mDisplayId);
@@ -401,6 +409,14 @@ public class CaptionWindowDecorViewModel implements WindowDecorViewModel {
                 },80);
             }else if (id == R.id.minimize_window) {
                 mTaskOperations.minimizeTask(mTaskToken);
+                RunningTaskInfo taskInfo = mTaskOrganizer.getRunningTaskInfo(mTaskId);
+                if( taskInfo.topActivity != null && taskInfo.magicWindowType != 0){
+                    RunningTaskInfo magicTaskInfo = mTaskOrganizer.getRunningTaskInfo(mTaskId,
+                            taskInfo.topActivity.getPackageName(), taskInfo.magicWindowType);
+                    if(magicTaskInfo != null){
+                        mTaskOperations.minimizeTask(magicTaskInfo.token);
+                    }
+                }
             } else if (id == R.id.maximize_window) {
                 Log.d(TAG, "onClick maximize_window");
                 RunningTaskInfo taskInfo = mTaskOrganizer.getRunningTaskInfo(mTaskId);

--- a/libs/WindowManager/Shell/src/com/android/wm/shell/windowdecor/FluidResizeTaskPositioner.java
+++ b/libs/WindowManager/Shell/src/com/android/wm/shell/windowdecor/FluidResizeTaskPositioner.java
@@ -27,9 +27,11 @@ import android.view.SurfaceControl;
 import android.window.TransitionInfo;
 import android.window.TransitionRequestInfo;
 import android.window.WindowContainerTransaction;
-
+import com.android.wm.shell.common.DisplayLayout;
+import android.util.SparseArray;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import android.app.ActivityManager.RunningTaskInfo;
 
 import com.android.wm.shell.ShellTaskOrganizer;
 import com.android.wm.shell.common.DisplayController;
@@ -55,6 +57,9 @@ class FluidResizeTaskPositioner implements DragPositioningCallback,
     private static final String TAG = "FluidResizeTaskPositioner";
     private final ShellTaskOrganizer mTaskOrganizer;
     private final Transitions mTransitions;
+    private TaskOperations mTaskOperations;
+    private SparseArray<CaptionWindowDecoration> mWindowDecorByTaskId;
+
     private final WindowDecoration mWindowDecoration;
     private final Supplier<SurfaceControl.Transaction> mTransactionSupplier;
     private DisplayController mDisplayController;
@@ -73,20 +78,22 @@ class FluidResizeTaskPositioner implements DragPositioningCallback,
     @Surface.Rotation private int mRotation;
 
     FluidResizeTaskPositioner(ShellTaskOrganizer taskOrganizer, Transitions transitions,
-            WindowDecoration windowDecoration, DisplayController displayController,
-            int disallowedAreaForEndBoundsHeight) {
+                              WindowDecoration windowDecoration, DisplayController displayController,
+                              int disallowedAreaForEndBoundsHeight, TaskOperations taskOperations, SparseArray<CaptionWindowDecoration> decorationSparseArray) {
         this(taskOrganizer, transitions, windowDecoration, displayController,
                 dragStartListener -> {}, SurfaceControl.Transaction::new,
                 disallowedAreaForEndBoundsHeight);
+        mTaskOperations = taskOperations;
+        mWindowDecorByTaskId = decorationSparseArray;
     }
 
     FluidResizeTaskPositioner(ShellTaskOrganizer taskOrganizer,
-            Transitions transitions,
-            WindowDecoration windowDecoration,
-            DisplayController displayController,
-            DragPositioningCallbackUtility.DragStartListener dragStartListener,
-            Supplier<SurfaceControl.Transaction> supplier,
-            int disallowedAreaForEndBoundsHeight) {
+                              Transitions transitions,
+                              WindowDecoration windowDecoration,
+                              DisplayController displayController,
+                              DragPositioningCallbackUtility.DragStartListener dragStartListener,
+                              Supplier<SurfaceControl.Transaction> supplier,
+                              int disallowedAreaForEndBoundsHeight) {
         mTaskOrganizer = taskOrganizer;
         mTransitions = transitions;
         mWindowDecoration = windowDecoration;
@@ -98,85 +105,166 @@ class FluidResizeTaskPositioner implements DragPositioningCallback,
 
     @Override
     public Rect onDragPositioningStart(int ctrlType, float x, float y) {
+        Log.d(TAG, "onDragPositioningStart called: ctrlType=" + ctrlType +
+                ", x=" + x + ", y=" + y);
+
         mCtrlType = ctrlType;
+
         mTaskBoundsAtDragStart.set(
                 mWindowDecoration.mTaskInfo.configuration.windowConfiguration.getBounds());
+
         mRepositionStartPoint.set(x, y);
         mDragStartListener.onDragStart(mWindowDecoration.mTaskInfo.taskId);
+
         if (mCtrlType != CTRL_TYPE_UNDEFINED && !mWindowDecoration.mTaskInfo.isFocused) {
+            Log.i(TAG, "Non-undefined ctrlType and task not focused. Reordering task to front.");
             WindowContainerTransaction wct = new WindowContainerTransaction();
             wct.reorder(mWindowDecoration.mTaskInfo.token, true);
             mTaskOrganizer.applyTransaction(wct);
         }
+
         mRepositionTaskBounds.set(mTaskBoundsAtDragStart);
+        Log.d(TAG, "mRepositionTaskBounds initialized to: " + mRepositionTaskBounds);
+
         int rotation = mWindowDecoration
                 .mTaskInfo.configuration.windowConfiguration.getDisplayRotation();
-        if (mStableBounds.isEmpty() || mRotation != rotation) {
+
+        boolean needUpdateStableBounds = mStableBounds.isEmpty() || mRotation != rotation;
+
+        if (needUpdateStableBounds) {
             mRotation = rotation;
-            mDisplayController.getDisplayLayout(mWindowDecoration.mDisplay.getDisplayId())
-                    .getStableBounds(mStableBounds);
+
+            int displayId = mWindowDecoration.mDisplay.getDisplayId();
+
+            DisplayLayout displayLayout = mDisplayController.getDisplayLayout(displayId);
+            if (displayLayout != null) {
+                displayLayout.getStableBounds(mStableBounds);
+            } else {
+                mStableBounds.setEmpty();
+            }
         }
-        return new Rect(mRepositionTaskBounds);
+
+        Rect resultBounds = new Rect(mRepositionTaskBounds);
+        Log.d(TAG, "onDragPositioningStart returning initial bounds: " + resultBounds);
+
+        return resultBounds;
     }
 
     @Override
     public Rect onDragPositioningMove(float x, float y) {
+        Log.d(TAG, "onDragPositioningMove called: x=" + x + ", y=" + y +
+                ", mCtrlType=" + mCtrlType + ", isResizing=" + isResizing());
+
         final WindowContainerTransaction wct = new WindowContainerTransaction();
+
         PointF delta = DragPositioningCallbackUtility.calculateDelta(x, y, mRepositionStartPoint);
+
         if (isResizing() && DragPositioningCallbackUtility.changeBounds(mCtrlType,
                 mRepositionTaskBounds, mTaskBoundsAtDragStart, mStableBounds, delta,
                 mDisplayController, mWindowDecoration)) {
+
+            Rect targetBounds  = new Rect();
+            RunningTaskInfo magicTaskInfo = getMagicTaskBounds(mWindowDecoration.mTaskInfo,
+                    mRepositionTaskBounds , targetBounds);
             // The task is being resized, send the |dragResizing| hint to core with the first
             // bounds-change wct.
             if (!mHasDragResized) {
                 // This is the first bounds change since drag resize operation started.
+                if(magicTaskInfo != null){
+                    wct.setDragResizing(magicTaskInfo.token, true /* dragResizing */);
+                }
                 wct.setDragResizing(mWindowDecoration.mTaskInfo.token, true /* dragResizing */);
+                mHasDragResized = true;
             }
+
             wct.setBounds(mWindowDecoration.mTaskInfo.token, mRepositionTaskBounds);
+            if(magicTaskInfo != null){
+                wct.setBounds(magicTaskInfo.token, targetBounds);
+                WindowDecoration magicWindowDecoration =
+                        mWindowDecorByTaskId.get(magicTaskInfo.taskId);
+                if (magicWindowDecoration != null && magicWindowDecoration.mTaskSurface != null) {
+                    final SurfaceControl.Transaction t = mTransactionSupplier.get();
+                    t.setPosition(magicWindowDecoration.mTaskSurface, targetBounds.left, targetBounds.top)
+                            .setWindowCrop(magicWindowDecoration.mTaskSurface, targetBounds.width(), targetBounds.height());
+                    t.apply();
+                }
+            }
             mTaskOrganizer.applyTransaction(wct);
-            mHasDragResized = true;
             mIsResizingOrAnimatingResize = true;
+
         } else if (mCtrlType == CTRL_TYPE_UNDEFINED) {
+            Log.d(TAG, "CTRL_TYPE_UNDEFINED");
+
             final SurfaceControl.Transaction t = mTransactionSupplier.get();
             DragPositioningCallbackUtility.setPositionOnDrag(mWindowDecoration,
                     mRepositionTaskBounds, mTaskBoundsAtDragStart, mRepositionStartPoint, t, x, y);
             t.apply();
+
+            Rect targetBounds  = new Rect();
+            RunningTaskInfo magicTaskInfo = getMagicTaskBounds(mWindowDecoration.mTaskInfo, mRepositionTaskBounds , targetBounds);
+            if(magicTaskInfo != null){
+                    final SurfaceControl.Transaction t1 = mTransactionSupplier.get();
+                    WindowDecoration magicWindowDecoration =
+                            mWindowDecorByTaskId.get(magicTaskInfo.taskId);
+                    t1.setPosition(magicWindowDecoration.mTaskSurface, targetBounds.left, targetBounds.top);
+                    t1.apply();
+            }
         }
-        return new Rect(mRepositionTaskBounds);
+
+        Rect resultBounds = new Rect(mRepositionTaskBounds);
+        Log.d(TAG, "onDragPositioningMove returning bounds: " + resultBounds);
+        return resultBounds;
     }
 
     @Override
     public Rect onDragPositioningEnd(float x, float y) {
-        // If task has been resized or task was dragged into area outside of
-        // mDisallowedAreaForEndBounds, apply WCT to finish it.
+        Log.d(TAG, "onDragPositioningEnd called: x=" + x + ", y=" + y);
         if (isResizing() && mHasDragResized) {
             final WindowContainerTransaction wct = new WindowContainerTransaction();
+
             wct.setDragResizing(mWindowDecoration.mTaskInfo.token, false /* dragResizing */);
-            PointF delta = DragPositioningCallbackUtility.calculateDelta(x, y,
-                    mRepositionStartPoint);
-            if (DragPositioningCallbackUtility.changeBounds(mCtrlType, mRepositionTaskBounds,
+
+            PointF delta = DragPositioningCallbackUtility.calculateDelta(x, y, mRepositionStartPoint);
+
+            boolean boundsChanged = DragPositioningCallbackUtility.changeBounds(mCtrlType, mRepositionTaskBounds,
                     mTaskBoundsAtDragStart, mStableBounds, delta, mDisplayController,
-                    mWindowDecoration)) {
+                    mWindowDecoration);
+
+            if (boundsChanged) {
                 wct.setBounds(mWindowDecoration.mTaskInfo.token, mRepositionTaskBounds);
             }
+
+            updateMagicTaskBounds(wct);
             mDragResizeEndTransition = mTransitions.startTransition(TRANSIT_CHANGE, wct, this);
+
         } else if (mCtrlType == CTRL_TYPE_UNDEFINED
                 && DragPositioningCallbackUtility.isBelowDisallowedArea(
                 mDisallowedAreaForEndBoundsHeight, mTaskBoundsAtDragStart, mRepositionStartPoint,
                 y)) {
+
             final WindowContainerTransaction wct = new WindowContainerTransaction();
+
             DragPositioningCallbackUtility.onDragEnd(mRepositionTaskBounds,
                     mTaskBoundsAtDragStart, mRepositionStartPoint, x, y,
                     mWindowDecoration.calculateValidDragArea());
             wct.setBounds(mWindowDecoration.mTaskInfo.token, mRepositionTaskBounds);
+            updateMagicTaskBounds(wct);
             mTransitions.startTransition(TRANSIT_CHANGE, wct, this);
+
         } else if(mCtrlType == CTRL_TYPE_UNDEFINED
                 && !DragPositioningCallbackUtility.isBelowDisallowedArea(
                 mDisallowedAreaForEndBoundsHeight, mTaskBoundsAtDragStart, mRepositionStartPoint,
                 y)){
-            mRepositionTaskBounds.offset(mDisallowedAreaForEndBoundsHeight - mRepositionTaskBounds.top, 0);
+
+            int offsetY = mDisallowedAreaForEndBoundsHeight - mRepositionTaskBounds.top;
+
+            mRepositionTaskBounds.offset(offsetY, 0);
+
             final WindowContainerTransaction wct = new WindowContainerTransaction();
+
             wct.setBounds(mWindowDecoration.mTaskInfo.token, mRepositionTaskBounds);
+
+            updateMagicTaskBounds(wct);
             mTransitions.startTransition(TRANSIT_CHANGE, wct, this);
         }
 
@@ -184,7 +272,29 @@ class FluidResizeTaskPositioner implements DragPositioningCallback,
         mRepositionStartPoint.set(0, 0);
         mCtrlType = CTRL_TYPE_UNDEFINED;
         mHasDragResized = false;
-        return new Rect(mRepositionTaskBounds);
+
+        Rect resultBounds = new Rect(mRepositionTaskBounds);
+        Log.d(TAG, "onDragPositioningEnd 返回边界: " + resultBounds);
+
+        return resultBounds;
+    }
+
+    private void updateMagicTaskBounds(WindowContainerTransaction wct) {
+        Rect targetBounds  = new Rect();
+        RunningTaskInfo magicTaskInfo = getMagicTaskBounds(mWindowDecoration.mTaskInfo,
+                mRepositionTaskBounds , targetBounds);
+        if(magicTaskInfo != null){
+            wct.setDragResizing(magicTaskInfo.token, false /* dragResizing */);
+            wct.setBounds(magicTaskInfo.token, targetBounds);
+            WindowDecoration magicWindowDecoration =
+                    mWindowDecorByTaskId.get(magicTaskInfo.taskId);
+            if (magicWindowDecoration != null && magicWindowDecoration.mTaskSurface != null) {
+                final SurfaceControl.Transaction t = mTransactionSupplier.get();
+                t.setPosition(magicWindowDecoration.mTaskSurface, targetBounds.left, targetBounds.top)
+                        .setWindowCrop(magicWindowDecoration.mTaskSurface, targetBounds.width(), targetBounds.height());
+                t.apply();
+            }
+        }
     }
 
     private boolean isResizing() {
@@ -194,17 +304,17 @@ class FluidResizeTaskPositioner implements DragPositioningCallback,
 
     @Override
     public boolean startAnimation(@NonNull IBinder transition, @NonNull TransitionInfo info,
-            @NonNull SurfaceControl.Transaction startTransaction,
-            @NonNull SurfaceControl.Transaction finishTransaction,
-            @NonNull Transitions.TransitionFinishCallback finishCallback) {
+                                  @NonNull SurfaceControl.Transaction startTransaction,
+                                  @NonNull SurfaceControl.Transaction finishTransaction,
+                                  @NonNull Transitions.TransitionFinishCallback finishCallback) {
         for (TransitionInfo.Change change: info.getChanges()) {
             final SurfaceControl sc = change.getLeash();
             final Rect endBounds = change.getEndAbsBounds();
             final Point endPosition = change.getEndRelOffset();
             startTransaction.setWindowCrop(sc, endBounds.width(), endBounds.height())
-                    .setPosition(sc,  endPosition.x, endPosition.y);
+                    .setPosition(sc, endBounds.left, endBounds.top);
             finishTransaction.setWindowCrop(sc, endBounds.width(), endBounds.height())
-                    .setPosition(sc,  endPosition.x, endPosition.y);
+                    .setPosition(sc, endBounds.left, endBounds.top);
 
             // Log.w(TAG,"startAnimation endPosition.x "+endPosition.x + ",endPosition.y: "+endPosition.y);   
             // Log.w(TAG,"startAnimation endBounds.left "+endBounds.left + ",endBounds.top: "+endBounds.top);       
@@ -219,6 +329,33 @@ class FluidResizeTaskPositioner implements DragPositioningCallback,
         return true;
     }
 
+    private RunningTaskInfo getMagicTaskBounds(RunningTaskInfo taskInfo, Rect sourceBounds,
+                                               Rect targetBounds){
+        if(mWindowDecoration.mTaskInfo.topActivity != null){
+            RunningTaskInfo magicTaskInfo = mTaskOrganizer.getRunningTaskInfo(taskInfo.taskId,
+                    taskInfo.topActivity.getPackageName(), taskInfo.magicWindowType);
+            if(magicTaskInfo != null){
+                targetBounds.set(
+                        magicTaskInfo.configuration.windowConfiguration.getBounds());
+                int width = targetBounds.width();
+                int height = sourceBounds.height();
+                if( mWindowDecoration.mTaskInfo.magicWindowType  == 1) {
+                    targetBounds.left = sourceBounds.right;
+                    targetBounds.right = targetBounds.left + width;
+                    targetBounds.top = sourceBounds.top;
+                    targetBounds.bottom = targetBounds.top + height;
+                } else {
+                    targetBounds.right = sourceBounds.left;
+                    targetBounds.left = targetBounds.right - width;
+                    targetBounds.top = sourceBounds.top;
+                    targetBounds.bottom = targetBounds.top + height;
+                }
+                return magicTaskInfo;
+            }
+        }
+        return null;
+    }
+
     /**
      * We should never reach this as this handler's transitions are only started from shell
      * explicitly.
@@ -226,13 +363,13 @@ class FluidResizeTaskPositioner implements DragPositioningCallback,
     @Nullable
     @Override
     public WindowContainerTransaction handleRequest(@NonNull IBinder transition,
-            @NonNull TransitionRequestInfo request) {
+                                                    @NonNull TransitionRequestInfo request) {
         return null;
     }
 
     @Override
     public void onTransitionConsumed(@NonNull IBinder transition, boolean aborted,
-            @Nullable SurfaceControl.Transaction finishTransaction) {
+                                     @Nullable SurfaceControl.Transaction finishTransaction) {
         if (transition.equals(mDragResizeEndTransition)) {
             mIsResizingOrAnimatingResize = false;
             mDragResizeEndTransition = null;

--- a/services/core/java/com/android/server/wm/ActivityClientController.java
+++ b/services/core/java/com/android/server/wm/ActivityClientController.java
@@ -41,6 +41,7 @@ import static android.view.Display.INVALID_DISPLAY;
 import static android.view.WindowManager.TRANSIT_CHANGE;
 import static android.view.WindowManager.TRANSIT_TO_BACK;
 import static android.view.WindowManager.TRANSIT_TO_FRONT;
+import static com.android.server.wm.Task.ADDITIONAL_WINDOW_ACTIVITY_LIMIT;
 
 import static com.android.internal.protolog.ProtoLogGroup.WM_DEBUG_CONFIGURATION;
 import static com.android.internal.protolog.ProtoLogGroup.WM_DEBUG_IMMERSIVE;
@@ -58,7 +59,10 @@ import static com.android.server.wm.ActivityTaskManagerService.RELAUNCH_REASON_N
 import static com.android.server.wm.ActivityTaskManagerService.TAG_SWITCH;
 import static com.android.server.wm.ActivityTaskManagerService.enforceNotIsolatedCaller;
 import static com.android.window.flags.Flags.allowDisableActivityRecordInputSink;
-
+import static com.android.server.wm.Task.NOT_MAGIC_WINDOW;
+import static com.android.server.wm.Task.MAGIC_MAIN_WINDOW;
+import static com.android.server.wm.Task.MAGIC_ADDITIONAL_WINDOW;
+import android.text.TextUtils;
 import android.Manifest;
 import android.annotation.ColorInt;
 import android.annotation.NonNull;
@@ -182,16 +186,54 @@ class ActivityClientController extends IActivityClientController.Stub {
                 if (r == null) {
                     return;
                 }
+                // fde start MAGIC WINDOW
+                // finish activity below, only one activity in additonal task
+                Task task = r.getTask();
+                if(task != null && task.type == MAGIC_ADDITIONAL_WINDOW){
+                    //remove more activities, limit 5 for some popu activity
+                    if(task.getTaskInfo().numActivities > ADDITIONAL_WINDOW_ACTIVITY_LIMIT){
+                        ActivityRecord root = task.getRootActivity();
+                        task.forAllActivities((actR) -> {
+                            if(actR != task.getTopNonFinishingActivity() && actR == root && actR != r){
+                                actR.finishIfPossible(0, null, null, "app-request", true /* oomAdj */);
+                            }
+                        });
+                    } else {
+                        task.forAllActivities((actR) -> {
+                            int type = mTaskSupervisor.getMagicWindowType(actR.intent.getComponent().getPackageName(), actR.intent.getComponent().flattenToShortString());
+                            if(type == MAGIC_MAIN_WINDOW){
+                                task.type = MAGIC_MAIN_WINDOW;
+                            }
+                        });
+                    }
+                }
+                // fde end
                 mTaskSupervisor.activityIdleInternal(r, false /* fromTimeout */,
                         false /* processPausingActivities */, config);
                 if (stopProfiling && r.hasProcess()) {
                     r.app.clearProfilerIfNeeded();
                 }
+                // fde start MAGIC WINDOW
+                // com.tencent.mm LaunchUI need a pause lifecycle to ensure focus update
+                if(task.type == MAGIC_ADDITIONAL_WINDOW && task.affinity.contains("com.tencent.mm")){
+                    Task magicMainTask = mService.mRootWindowContainer.findMagicTask(task.mWindowLayoutAffinity, MAGIC_MAIN_WINDOW);
+                    if(magicMainTask != null && magicMainTask.getTopNonFinishingActivity() != null ){
+                        magicMainTask.getTopNonFinishingActivity().pauseActivityLockedOnly();
+                    }
+                }
+                // fde end
             }
         } finally {
             Trace.traceEnd(TRACE_TAG_WINDOW_MANAGER);
             Binder.restoreCallingIdentity(origId);
         }
+    }
+
+    boolean isSameMagicTask(Task task1, Task task2){
+        if(task1 == null || task2 == null || task1.type != MAGIC_ADDITIONAL_WINDOW || task2.type != MAGIC_ADDITIONAL_WINDOW){
+            return false;
+        }
+        return TextUtils.equals(task1.affinity, task2.affinity);
     }
 
     @Override
@@ -522,6 +564,17 @@ class ActivityClientController extends IActivityClientController.Stub {
                     res = true;
                     // Explicitly dismissing the activity so reset its relaunch flag.
                     r.mRelaunchReason = RELAUNCH_REASON_NONE;
+
+                    // fde start MAGIC WINDOW finish another MAGIC_ADDITIONAL_WINDOW
+                    if(tr.type == MAGIC_MAIN_WINDOW){
+                        Task magic = mService.mRootWindowContainer.findMagicTask(tr.mWindowLayoutAffinity, MAGIC_ADDITIONAL_WINDOW);
+                        if(magic != null){
+                            mTaskSupervisor.removeTask(magic, true /*killProcess*/,
+                                    true, "finish-activity-bymagic");
+                        }
+                    }
+                    // fde end
+
                 } else {
                     r.finishIfPossible(resultCode, resultData, resultGrants, "app-request",
                             true /* oomAdj */);

--- a/services/core/java/com/android/server/wm/ActivityRecord.java
+++ b/services/core/java/com/android/server/wm/ActivityRecord.java
@@ -496,7 +496,7 @@ final class ActivityRecord extends WindowToken implements WindowManagerService.A
     @Nullable
     final String launchedFromFeatureId; // always the feature in launchedFromPackage
     private final int mLaunchSourceType; // original launch source type
-    final Intent intent;    // the original intent that generated us
+    public final Intent intent;    // the original intent that generated us
     final String shortComponentName; // the short component name of the intent
     final String resolvedType; // as per original caller;
     final String processName; // process where this component wants to run
@@ -10118,6 +10118,36 @@ final class ActivityRecord extends WindowToken implements WindowManagerService.A
 
         configChangeFlags = 0;
     }
+
+
+    void pauseActivityLockedOnly() {
+        mAtmService.mH.postDelayed(PauseRunnable, 0);
+    }
+
+
+    private final Runnable PauseRunnable = new Runnable() {
+        @Override
+        public void run() {
+            if(app == null){
+                return;
+            }
+            try {
+            mAtmService.getLifecycleManager().scheduleTransactionItem(app.getThread(),
+                    PauseActivityItem.obtain(token, finishing, false /* userLeaving */,
+                            configChangeFlags, false /* dontReport */, mAutoEnteringPip));
+                // Note: don't need to call pauseIfSleepingLocked() here, because the caller will only
+                // request resume if this activity is currently resumed, which implies we aren't
+                // sleeping.
+                removePauseTimeout();
+                setState(PAUSED, "pauseActivityLockedOnly");
+            } catch (RemoteException e) {
+                if (DEBUG_SWITCH ) Slog.i(TAG_SWITCH, "relaunchActivityLockedOnly failed", e);
+            }
+            mRootWindowContainer.resumeFocusedTasksTopActivities();
+            setState(RESUMED, "pauseActivityLockedOnly");
+        }
+    };
+
 
     /**
      * Request the process of the activity to restart with its saved state (from

--- a/services/core/java/com/android/server/wm/ActivityStarter.java
+++ b/services/core/java/com/android/server/wm/ActivityStarter.java
@@ -140,6 +140,9 @@ import com.android.server.wm.BackgroundActivityStartController.BalCode;
 import com.android.server.wm.BackgroundActivityStartController.BalVerdict;
 import com.android.server.wm.LaunchParamsController.LaunchParams;
 import com.android.server.wm.TaskFragment.EmbeddingCheckResult;
+import static com.android.server.wm.Task.NOT_MAGIC_WINDOW;
+import static com.android.server.wm.Task.MAGIC_MAIN_WINDOW;
+import static com.android.server.wm.Task.MAGIC_ADDITIONAL_WINDOW;
 
 import java.io.PrintWriter;
 import java.lang.annotation.Retention;
@@ -204,6 +207,8 @@ class ActivityStarter {
     private int mLaunchMode;
     private boolean mLaunchTaskBehind;
     private int mLaunchFlags;
+    private boolean mMagicLaunch = false;
+    private String mWindowAffinity = null;
 
     private LaunchParams mLaunchParams = new LaunchParams();
 
@@ -432,6 +437,8 @@ class ActivityStarter {
          * {@link PendingRemoteAnimationRegistry}
          */
         boolean allowPendingRemoteAnimationRegistryLookup;
+
+        String extraFDE;
 
         /**
          * Ensure constructed request matches reset instance.
@@ -963,6 +970,36 @@ class ActivityStarter {
         final int startFlags = request.startFlags;
         final SafeActivityOptions options = request.activityOptions;
         Task inTask = request.inTask;
+        // fde start: MAGIC WINDOW
+        // int magicType = mSupervisor.getMagicWindowType(aInfo.packageName, aInfo.name);
+        Slog.d(TAG, "executeRequest: packageName=" + aInfo.packageName + " name=" + aInfo.name);
+        boolean isMagicPackage = false;
+        String extraFDE = request.extraFDE;
+        if(intent != null && extraFDE != null){
+            isMagicPackage = TextUtils.equals(extraFDE, "true");
+            Slog.d(TAG, "query isMagicPackage:" + isMagicPackage  + "  extraFDE:"
+                    + extraFDE);
+            mSupervisor.updateMagicFromCompatibleConfig(aInfo.packageName, isMagicPackage);
+        }
+        int magicType = 0;
+        if(isMagicPackage) {
+            magicType = mSupervisor.getMagicWindowType(aInfo.packageName, aInfo.name);
+        }
+        // mSupervisor.loadMagicWindowConfig(); for debug
+        if( isMagicPackage
+                &&  magicType == MAGIC_ADDITIONAL_WINDOW) {
+            Task task = mRootWindowContainer.findMagicTask(aInfo.taskAffinity, MAGIC_MAIN_WINDOW);
+            if(task != null){
+                mMagicLaunch = true;
+                aInfo.documentLaunchMode = DOCUMENT_LAUNCH_ALWAYS;
+            }
+            mWindowAffinity = aInfo.taskAffinity;
+        } else {
+            mMagicLaunch = false;
+        }
+        Slog.d(TAG, "isMagicPackage:" + isMagicPackage + " magicType:" + magicType);
+        // fde end
+
         TaskFragment inTaskFragment = request.inTaskFragment;
 
         int err = ActivityManager.START_SUCCESS;
@@ -1728,7 +1765,15 @@ class ActivityStarter {
         // Get top task at beginning because the order may be changed when reusing existing task.
         final Task prevTopRootTask = mPreferredTaskDisplayArea.getFocusedRootTask();
         final Task prevTopTask = prevTopRootTask != null ? prevTopRootTask.getTopLeafTask() : null;
-        final Task reusedTask = getReusableTask();
+        Task reusedTask = null;
+        // fde start: MAGIC WINDOW
+        if(mMagicLaunch){
+            reusedTask  = mRootWindowContainer.findMagicTask(mWindowAffinity, MAGIC_ADDITIONAL_WINDOW);
+            mAddingToTask = true;
+            // fde end
+        } else {
+            reusedTask = getReusableTask();
+        }
 
         // If requested, freeze the task list
         if (mOptions != null && mOptions.freezeRecentTasksReordering()
@@ -1968,7 +2013,11 @@ class ActivityStarter {
 
     /** Returns the leaf task where the target activity may be placed. */
     private Task computeTargetTask() {
-        if (mStartActivity.resultTo == null && mInTask == null && !mAddingToTask
+        // fde start: MAGIC WINDOW
+        if(mMagicLaunch) {
+            return null;
+            // fde end
+        } else if (mStartActivity.resultTo == null && mInTask == null && !mAddingToTask
                 && (mLaunchFlags & FLAG_ACTIVITY_NEW_TASK) != 0) {
             // A new task should be created instead of using existing one.
             return null;
@@ -3088,6 +3137,10 @@ class ActivityStarter {
     }
 
     ActivityStarter setIntent(Intent intent) {
+        if(intent != null){
+            String extraFDE = intent.getExtraFDE();
+            mRequest.extraFDE = extraFDE;
+        }
         mRequest.intent = intent;
         return this;
     }

--- a/services/core/java/com/android/server/wm/ActivityTaskManagerService.java
+++ b/services/core/java/com/android/server/wm/ActivityTaskManagerService.java
@@ -131,7 +131,10 @@ import static com.android.server.wm.RootWindowContainer.MATCH_ATTACHED_TASK_OR_R
 import static com.android.server.wm.Task.REPARENT_KEEP_ROOT_TASK_AT_FRONT;
 import static com.android.server.wm.WindowManagerService.MY_PID;
 import static com.android.server.wm.WindowManagerService.UPDATE_FOCUS_NORMAL;
-
+import static com.android.server.wm.Task.NOT_MAGIC_WINDOW;
+import static com.android.server.wm.Task.MAGIC_MAIN_WINDOW;
+import static com.android.server.wm.Task.MAGIC_ADDITIONAL_WINDOW;
+import android.text.TextUtils;
 import android.Manifest;
 import android.annotation.IntDef;
 import android.annotation.NonNull;
@@ -2145,6 +2148,15 @@ public class ActivityTaskManagerService extends IActivityTaskManager.Stub {
                     // int taskId = ActivityRecord.getTaskForActivityLocked(token, !nonRoot);
                     final Task task = mRootWindowContainer.anyTaskForId(taskId);
                     if (task != null) {
+                        // fde start MAGIC WINDOW
+                        if(task.type == MAGIC_MAIN_WINDOW || task.type == MAGIC_ADDITIONAL_WINDOW){
+                            Task companion = mRootWindowContainer.findMagicTask(task.mWindowLayoutAffinity,
+                                    task.type == MAGIC_MAIN_WINDOW ? MAGIC_ADDITIONAL_WINDOW : MAGIC_MAIN_WINDOW);
+                            if(companion != null){
+                                companion.getRootTask().moveTaskToBack(companion);
+                            }
+                        }
+                        // fde end
                         return task.getRootTask().moveTaskToBack(task);
                     }
                 } finally {
@@ -2315,6 +2327,17 @@ public class ActivityTaskManagerService extends IActivityTaskManager.Stub {
             ActivityOptions realOptions = options != null
                     ? options.getOptions(mTaskSupervisor)
                     : null;
+            // fde start MAGIC WINDOW
+            if(task.type == MAGIC_MAIN_WINDOW || task.type == MAGIC_ADDITIONAL_WINDOW){
+                Task companion = mRootWindowContainer.findMagicTask(task.mWindowLayoutAffinity,
+                        task.type == MAGIC_MAIN_WINDOW ? MAGIC_ADDITIONAL_WINDOW : MAGIC_MAIN_WINDOW);
+                if(companion != null){
+                    Slog.e(TAG, "findTaskToMoveToFront task:" + task + " flags:" + flags + " companion" + companion);
+                    companion.moveTaskToFront(companion, false /* noAnimation */, null,
+                            companion.getTopNonFinishingActivity() == null ? null : companion.getTopNonFinishingActivity().appTimeTracker, "moveTaskToFront");
+                }
+            }
+            // fde end
             mTaskSupervisor.findTaskToMoveToFront(task, flags, realOptions, "moveTaskToFront",
                     false /* forceNonResizable */);
         } finally {
@@ -2963,6 +2986,32 @@ public class ActivityTaskManagerService extends IActivityTaskManager.Stub {
                 // Reparent the task to the right root task if necessary
                 boolean preserveWindow = (resizeMode & RESIZE_MODE_PRESERVE_WINDOW) != 0;
 
+                // fde start MAGIC WINDOW
+                if(task.type == MAGIC_MAIN_WINDOW || task.type == MAGIC_ADDITIONAL_WINDOW ){
+                    Task bMostTask = mRootWindowContainer.getBottomMostTask();
+                    Task relative = null;
+                    while(bMostTask != null ){
+                        if( TextUtils.equals(task.affinity, bMostTask.affinity)){
+                            relative = bMostTask;
+                            break;
+                        }
+                        Task above = mRootWindowContainer.getTaskAbove(bMostTask);
+                        // Slog.e(TAG, "resizeTask: bMostTask=" + bMostTask + " above=" + above);
+                        bMostTask = above;
+                    }
+                    if(relative != null && relative != task){
+                        Rect b = new Rect(bounds);
+                        if(relative.type == MAGIC_ADDITIONAL_WINDOW){
+                            b.left = b.left + bounds.right - bounds.left;
+                            b.right = b.right + bounds.right - bounds.left;
+                        } else if(relative.type == MAGIC_MAIN_WINDOW){
+                            b.left = b.left - bounds.right + bounds.left;
+                            b.right = b.right - bounds.right + bounds.left;
+                        }
+                        relative.resize(b, resizeMode, preserveWindow);
+                    }
+                }
+                // fde end
                 if (!getTransitionController().isShellTransitionsEnabled()) {
                     // After reparenting (which only resizes the task to the root task bounds),
                     // resize the task to the actual bounds provided

--- a/services/core/java/com/android/server/wm/ActivityTaskSupervisor.java
+++ b/services/core/java/com/android/server/wm/ActivityTaskSupervisor.java
@@ -50,7 +50,9 @@ import static android.view.Display.DEFAULT_DISPLAY;
 import static android.view.Display.INVALID_DISPLAY;
 import static android.view.WindowManager.TRANSIT_TO_BACK;
 import static android.view.WindowManager.TRANSIT_TO_FRONT;
-
+import static com.android.server.wm.Task.NOT_MAGIC_WINDOW;
+import static com.android.server.wm.Task.MAGIC_MAIN_WINDOW;
+import static com.android.server.wm.Task.MAGIC_ADDITIONAL_WINDOW;
 import static com.android.internal.protolog.ProtoLogGroup.WM_DEBUG_STATES;
 import static com.android.internal.protolog.ProtoLogGroup.WM_DEBUG_TASKS;
 import static com.android.server.wm.ActivityRecord.State.PAUSED;
@@ -156,7 +158,22 @@ import com.android.server.am.UserState;
 import com.android.server.pm.PackageManagerServiceUtils;
 import com.android.server.utils.Slogf;
 import com.android.server.wm.ActivityMetricsLogger.LaunchingState;
-
+import android.os.Environment;
+import android.text.TextUtils;
+import android.util.Xml;
+import com.android.internal.util.FunctionalUtils;
+import org.xmlpull.v1.XmlPullParser;
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileDescriptor;
+import java.io.FileReader;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.function.IntFunction;
+import libcore.io.IoUtils;
 import java.io.FileDescriptor;
 import java.io.PrintWriter;
 import java.util.ArrayList;
@@ -192,6 +209,20 @@ public class ActivityTaskSupervisor implements RecentTasks.Callbacks {
 
     /** How long we wait until giving up on the activity telling us it released the top state. */
     private static final int TOP_RESUMED_STATE_LOSS_TIMEOUT = 500;
+
+    /**
+     * load magic window config
+     */
+    public HashMap<String, String> mMagicWindowConfig = new HashMap<>();
+    private static final String MAGIC_WINDOW_DIRNAME = "magicwindow_config";
+    private static final String MAGIC_WINDOW_FILE_SUFFIX = ".xml";
+    private static final String MAGIC_WINDOW_CONFIG_FILENAME = "magic_config";
+    private static final String MAGIC_WINDOW_TAG = "package";
+    private static final String MAGIC_WINDOW_KEY = "packagename";
+    private static final String MAGIC_WINDOW_VALUE = "main";
+    private static final String MAGIC_WINDOW_CONFIG_DIRNAME_SYSTEM = "/system/magicwindow_config/";
+
+
 
     /**
      * The timeout to kill task processes if its activity didn't complete destruction in time
@@ -470,6 +501,91 @@ public class ActivityTaskSupervisor implements RecentTasks.Callbacks {
         mLaunchParamsController.registerDefaultModifiers(this);
 
         mBalController = new BackgroundActivityStartController(mService, this);
+        loadMagicWindowConfig();
+    }
+
+    public void loadMagicWindowConfig() {
+//        IntFunction<File> userFolderGetter = Environment::getDataSystemCeDirectory;
+//        File userFolder = userFolderGetter.apply(0);
+        File magicWindowConfigFileDir = new File("/system/", MAGIC_WINDOW_DIRNAME);
+        if (!magicWindowConfigFileDir.isDirectory()) {
+            Slog.i(TAG, "Didn't find magic config folder for user " + 0);
+            magicWindowConfigFileDir = new File(MAGIC_WINDOW_CONFIG_DIRNAME_SYSTEM);
+        } else if(!magicWindowConfigFileDir.isDirectory()){
+            Slog.i(TAG, "Didn't find magic config folder in system for user " + 0);
+            return;
+        }
+        File magicWindowConfigFile = new File(magicWindowConfigFileDir,
+                MAGIC_WINDOW_CONFIG_FILENAME + MAGIC_WINDOW_FILE_SUFFIX);
+        if (!magicWindowConfigFile.exists()) {
+            Slog.i(TAG, "Didn't find magic config file for user " + 0);
+            return;
+        }
+        BufferedReader reader = null;
+        try {
+            reader = new BufferedReader(new FileReader(magicWindowConfigFile));
+            final XmlPullParser parser = Xml.newPullParser();
+            parser.setInput(reader);
+            int event;
+            while ((event = parser.next()) != XmlPullParser.END_DOCUMENT
+            ) {
+                if (event != XmlPullParser.START_TAG) {
+                    continue;
+                }
+
+                final String tagName = parser.getName();
+                if (!MAGIC_WINDOW_TAG.equals(tagName)) {
+                    Slog.w(TAG, "Unexpected tag name: " + tagName);
+                    continue;
+                }
+                String packagename = null, main = null;
+                for (int i = 0; i < parser.getAttributeCount(); ++i) {
+                    final String attrValue = parser.getAttributeValue(i);
+                    switch (parser.getAttributeName(i)) {
+                        case MAGIC_WINDOW_KEY:
+                            packagename = attrValue;
+                            break;
+                        case MAGIC_WINDOW_VALUE:
+                            main = attrValue;
+                            break;
+                        default:
+                            break;
+                    }
+                }
+                if (!TextUtils.isEmpty(packagename) && !TextUtils.isEmpty(main)) {
+                    // Slog.e(TAG, "magic window packagename:" + packagename + " main:" + main);
+                    mMagicWindowConfig.put(packagename, main);
+                }
+            }
+
+        } catch (Exception e) {
+            Slog.w(TAG, "Failed to loadmagic config for " + magicWindowConfigFileDir.getName(), e);
+            magicWindowConfigFile.delete();
+        } finally {
+            IoUtils.closeQuietly(reader);
+        }
+    }
+
+    public void updateMagicFromCompatibleConfig(String packagename, boolean isMagic){
+        if(isMagic || TextUtils.isEmpty(packagename) || !mMagicWindowConfig.containsKey(packagename)){
+            return;
+        }
+        mMagicWindowConfig.remove(packagename);
+    }
+
+
+    public int getMagicWindowType(String packageName, String activity) {
+        // Slog.e(TAG, " package:" + packageName + " activity:" + activity);
+        if(TextUtils.isEmpty(packageName) || TextUtils.isEmpty(activity)){
+            return NOT_MAGIC_WINDOW; //not magic window
+        } else if(!mMagicWindowConfig.containsKey(packageName)) {
+            return NOT_MAGIC_WINDOW; // not magic window
+        } else if(!activity.contains(mMagicWindowConfig.get(packageName))){
+            return MAGIC_ADDITIONAL_WINDOW; //  magic additional window
+        } else if(activity.contains(mMagicWindowConfig.get(packageName))){
+            return MAGIC_MAIN_WINDOW; //  magic main window
+        }
+        return NOT_MAGIC_WINDOW;
     }
 
     void onSystemReady() {

--- a/services/core/java/com/android/server/wm/LaunchParamsController.java
+++ b/services/core/java/com/android/server/wm/LaunchParamsController.java
@@ -180,6 +180,8 @@ class LaunchParamsController {
         /** The bounds within the parent container. */
         final Rect mBounds = new Rect();
 
+        int mAdditionalMagicWindowWidth;
+
         /** The display area the {@link Task} would prefer to be on. */
         @Nullable
         TaskDisplayArea mPreferredTaskDisplayArea;
@@ -197,6 +199,7 @@ class LaunchParamsController {
         /** Copies the values set on the passed in {@link LaunchParams}. */
         void set(LaunchParams params) {
             mBounds.set(params.mBounds);
+            this.mAdditionalMagicWindowWidth = params.mAdditionalMagicWindowWidth;
             mPreferredTaskDisplayArea = params.mPreferredTaskDisplayArea;
             mWindowingMode = params.mWindowingMode;
         }

--- a/services/core/java/com/android/server/wm/LaunchParamsPersister.java
+++ b/services/core/java/com/android/server/wm/LaunchParamsPersister.java
@@ -36,7 +36,9 @@ import com.android.modules.utils.TypedXmlSerializer;
 import com.android.server.LocalServices;
 import com.android.server.pm.PackageList;
 import com.android.server.wm.LaunchParamsController.LaunchParams;
-
+import static com.android.server.wm.Task.MAGIC_ADDITIONAL_WINDOW;
+import static com.android.server.wm.Task.MAGIC_MAIN_WINDOW;
+import static com.android.server.wm.Task.NOT_MAGIC_WINDOW;
 import org.xmlpull.v1.XmlPullParser;
 
 import java.io.ByteArrayOutputStream;
@@ -256,10 +258,36 @@ class LaunchParamsPersister {
         addComponentNameToLaunchParamAffinityMapIfNotNull(name, params.mWindowLayoutAffinity);
 
         if (changed) {
-            mPersisterQueue.updateLastOrAddItem(
-                    new LaunchParamsWriteQueueItem(userId, name, params),
-                    /* flush */ false);
+            LaunchParamsWriteQueueItem item = new LaunchParamsWriteQueueItem(userId, name, params);
+//            Slog.e(TAG, "saveTask item:" + params);
+            mPersisterQueue.updateLastOrAddItem( item,  /* flush */ false);
         }
+
+        // fde start MAGIC WINDOW
+        Task magic = null;
+        if(task.type == MAGIC_ADDITIONAL_WINDOW){
+            magic = mSupervisor.mRootWindowContainer.findMagicTask(task.mWindowLayoutAffinity, MAGIC_MAIN_WINDOW);
+        }
+        if(magic != null && changed && magic.getTopNonFinishingActivity() != null){
+            final ComponentName magicName = magic.getTopNonFinishingActivity().mActivityComponent;
+            if (magicName == null) {
+                return;
+            }
+            PersistableLaunchParams magicParams =  map.computeIfAbsent(magicName, componentName -> new PersistableLaunchParams());
+
+            if (task.mLastNonFullscreenBounds != null) {
+                Rect rect = task.mLastNonFullscreenBounds;
+                magicParams.mAdditionalMagicWindowWidth = rect.width();
+                Slog.e(TAG, "save magic Task:" + magicName +  " mAdditionalMagicWindowWidth:" + rect.width());
+
+            } else {
+                magicParams.mAdditionalMagicWindowWidth = 0;
+            }
+            LaunchParamsWriteQueueItem item = new LaunchParamsWriteQueueItem(userId, magicName, magicParams);
+           Slog.e(TAG, "saveTask  magic item:" + magicParams + " magicName:" + magicName);
+            mPersisterQueue.updateLastOrAddItem(item, /* flush */ false);
+        }
+        // fde end
     }
 
     private boolean saveTaskToLaunchParam(
@@ -305,9 +333,10 @@ class LaunchParamsPersister {
         final ComponentName name = task != null ? task.realActivity : activity.mActivityComponent;
         final int userId = task != null ? task.mUserId : activity.mUserId;
         final String windowLayoutAffinity;
+        int magicType = mSupervisor.getMagicWindowType(name.getPackageName(), name.getShortClassName());
         if (task != null) {
             windowLayoutAffinity = task.mWindowLayoutAffinity;
-        } else {
+        } else if(magicType == NOT_MAGIC_WINDOW){
             ActivityInfo.WindowLayout layout = activity.info.windowLayout;
             // region @boringdroid
             // windowLayoutAffinity = layout == null ? null : layout.windowLayoutAffinity;
@@ -321,6 +350,8 @@ class LaunchParamsPersister {
             } else {
                 windowLayoutAffinity = null;
             }
+        } else {
+            windowLayoutAffinity = null;
         }
 
         outParams.reset();
@@ -334,7 +365,8 @@ class LaunchParamsPersister {
         // Next we'll compare these params against all existing params with the same affinity and
         // use the newest one.
         if (windowLayoutAffinity != null
-                && mWindowLayoutAffinityMap.get(windowLayoutAffinity) != null) {
+                && mWindowLayoutAffinityMap.get(windowLayoutAffinity) != null
+                && magicType == NOT_MAGIC_WINDOW) {
             ArraySet<ComponentName> candidates = mWindowLayoutAffinityMap.get(windowLayoutAffinity);
             for (int i = 0; i < candidates.size(); ++i) {
                 ComponentName candidate = candidates.valueAt(i);
@@ -363,6 +395,23 @@ class LaunchParamsPersister {
         }
         outParams.mWindowingMode = persistableParams.mWindowingMode;
         outParams.mBounds.set(persistableParams.mBounds);
+
+        // fde start MAGIC WINDOW
+        if(task != null && task.type == MAGIC_ADDITIONAL_WINDOW){
+            Task magic = mSupervisor.mRootWindowContainer.findMagicTask(task.mWindowLayoutAffinity, MAGIC_MAIN_WINDOW);
+            if(magic == null){
+                return;
+            }
+            if(magic.getTopNonFinishingActivity() == null){
+                return;
+            }
+            final ComponentName magicName = magic.getTopNonFinishingActivity().mActivityComponent;
+            PersistableLaunchParams magicParams = map.get(magicName);
+            if(magicParams != null && magicParams.mAdditionalMagicWindowWidth != 0){
+                outParams.mAdditionalMagicWindowWidth = magicParams.mAdditionalMagicWindowWidth;
+            }
+        }
+        // fde end
     }
 
     void removeRecordForPackage(String packageName) {
@@ -415,9 +464,9 @@ class LaunchParamsPersister {
     private class LaunchParamsWriteQueueItem
             implements PersisterQueue.WriteQueueItem<LaunchParamsWriteQueueItem> {
         private final int mUserId;
-        private final ComponentName mComponentName;
+        public final ComponentName mComponentName;
 
-        private PersistableLaunchParams mLaunchParams;
+        public PersistableLaunchParams mLaunchParams;
 
         private LaunchParamsWriteQueueItem(int userId, ComponentName componentName,
                 PersistableLaunchParams launchParams) {
@@ -506,6 +555,7 @@ class LaunchParamsPersister {
         private static final String ATTR_DISPLAY_UNIQUE_ID = "display_unique_id";
         private static final String ATTR_BOUNDS = "bounds";
         private static final String ATTR_WINDOW_LAYOUT_AFFINITY = "window_layout_affinity";
+        private static final String ATTR_ADDITIONAL_MAGIC_WINDOW_WIDTH = "additional_magic_window_width";
 
         /** The bounds within the parent container. */
         final Rect mBounds = new Rect();
@@ -515,6 +565,11 @@ class LaunchParamsPersister {
 
         /** The windowing mode to be in. */
         int mWindowingMode;
+
+        /**
+         * Additional width to be added to the magic window.
+         */
+        int mAdditionalMagicWindowWidth;
 
         /**
          * Last {@link android.content.pm.ActivityInfo.WindowLayout#windowLayoutAffinity} of the
@@ -529,13 +584,24 @@ class LaunchParamsPersister {
         long mTimestamp;
 
         void saveToXml(TypedXmlSerializer serializer) throws IOException {
+            if( mDisplayUniqueId == null){
+                return;
+            }
+//            Slog.e(TAG, "saveToXml mDisplayUniqueId:" + mDisplayUniqueId);
+//            Slog.e(TAG, "saveToXml mWindowingMode:" + mWindowingMode);
+//            Slog.e(TAG, "saveToXml mBounds:" + mBounds.flattenToString());
+//            Slog.e(TAG, "saveToXml mWindowLayoutAffinity:" + mWindowLayoutAffinity);
+//            Slog.e(TAG, "saveToXml mAdditionalMagicWindowWidth:" + Integer.toString(mAdditionalMagicWindowWidth));
             serializer.attribute(null, ATTR_DISPLAY_UNIQUE_ID, mDisplayUniqueId);
             serializer.attributeInt(null, ATTR_WINDOWING_MODE, mWindowingMode);
             serializer.attribute(null, ATTR_BOUNDS, mBounds.flattenToString());
             if (mWindowLayoutAffinity != null) {
                 serializer.attribute(null, ATTR_WINDOW_LAYOUT_AFFINITY, mWindowLayoutAffinity);
             }
-        }
+            if(mAdditionalMagicWindowWidth > 0){
+                serializer.attribute(null, ATTR_ADDITIONAL_MAGIC_WINDOW_WIDTH, Integer.toString(mAdditionalMagicWindowWidth));
+            }
+         }
 
         void restore(File xmlFile, TypedXmlPullParser parser) {
             for (int i = 0; i < parser.getAttributeCount(); ++i) {
@@ -557,6 +623,9 @@ class LaunchParamsPersister {
                     case ATTR_WINDOW_LAYOUT_AFFINITY:
                         mWindowLayoutAffinity = attrValue;
                         break;
+                    case ATTR_ADDITIONAL_MAGIC_WINDOW_WIDTH:
+                        mAdditionalMagicWindowWidth =  Integer.parseInt(attrValue);
+                        break;
                 }
             }
 
@@ -572,6 +641,7 @@ class LaunchParamsPersister {
             builder.append(" windowingMode=" + mWindowingMode);
             builder.append(" displayUniqueId=" + mDisplayUniqueId);
             builder.append(" bounds=" + mBounds);
+            builder.append(" mAdditionalMagicWindowWidth=" + mAdditionalMagicWindowWidth);
             if (mWindowLayoutAffinity != null) {
                 builder.append(" launchParamsAffinity=" + mWindowLayoutAffinity);
             }

--- a/services/core/java/com/android/server/wm/RootWindowContainer.java
+++ b/services/core/java/com/android/server/wm/RootWindowContainer.java
@@ -84,8 +84,12 @@ import static com.android.server.wm.WindowManagerService.WINDOWS_FREEZING_SCREEN
 import static com.android.server.wm.WindowSurfacePlacer.SET_UPDATE_ROTATION;
 import static com.android.server.wm.WindowSurfacePlacer.SET_WALLPAPER_ACTION_PENDING;
 import static com.android.systemui.shared.Flags.enableHomeDelay;
+import static com.android.server.wm.Task.NOT_MAGIC_WINDOW;
+import static com.android.server.wm.Task.MAGIC_MAIN_WINDOW;
+import static com.android.server.wm.Task.MAGIC_ADDITIONAL_WINDOW;
 
 import static java.lang.Integer.MAX_VALUE;
+import android.text.TextUtils;
 
 import android.annotation.IntDef;
 import android.annotation.NonNull;
@@ -2358,6 +2362,23 @@ class RootWindowContainer extends WindowContainer<DisplayContent>
         }
         return candidateActivity;
     }
+
+    // fde start MAGIC WINODW
+    public Task findMagicTask(String windowAffinity, int type){
+        Task bMostTask = getBottomMostTask();
+        while(bMostTask != null ){
+            // Slog.e(TAG, "findMagicTask():  windowAffinity :" + windowAffinity + " bMostTask:" + bMostTask);
+            if( bMostTask.mWindowLayoutAffinity!= null
+                    && windowAffinity != null
+                    && bMostTask.mWindowLayoutAffinity.contains(windowAffinity)
+                    && bMostTask.type == type){
+                return bMostTask;
+            }
+            bMostTask = getTaskAbove(bMostTask);
+        }
+        return null;
+    }
+    // fde end MAGIC WINDOW
 
     /**
      * Finish the topmost activities in all root tasks that belong to the crashed app.

--- a/services/core/java/com/android/server/wm/Task.java
+++ b/services/core/java/com/android/server/wm/Task.java
@@ -281,6 +281,11 @@ class Task extends TaskFragment {
 
     private static final String FINISH_LOAD_DESKTOP = "1";
 
+    public int type = NOT_MAGIC_WINDOW; // main magic window: 1  additional main window: 2
+    public static final int NOT_MAGIC_WINDOW = 0 , MAGIC_MAIN_WINDOW = 1, MAGIC_ADDITIONAL_WINDOW = 2;
+    public static final int ADDITIONAL_WINDOW_ACTIVITY_LIMIT = 5;
+
+
     /**
      * The modes to control how root task is moved to the front when calling {@link Task#reparent}.
      */
@@ -325,7 +330,7 @@ class Task extends TaskFragment {
 
     int mCurrentUser;
 
-    String affinity;        // The affinity name for this task, or null; may change identity.
+    public String affinity;        // The affinity name for this task, or null; may change identity.
     String rootAffinity;    // Initial base affinity, or null; does not change from initial root.
     String mWindowLayoutAffinity; // Launch param affinity of this task or null. Used when saving
                                 // launch params of this task.
@@ -963,6 +968,21 @@ class Task extends TaskFragment {
      */
     void setIntent(ActivityRecord r, @Nullable Intent intent, @Nullable ActivityInfo info) {
         boolean updateIdentity = false;
+        // fde start MAGIC WINDOW
+        if(info != null){
+            type = mTaskSupervisor.getMagicWindowType(info.packageName, info.name);
+        } else {
+            type = mTaskSupervisor.getMagicWindowType(r.intent.getComponent().getPackageName(), r.intent.getComponent().getClassName());
+            // never update type in main window because it will insert a additional window in this task
+            if (type != MAGIC_MAIN_WINDOW) {
+                if (info != null) {
+                    type = mTaskSupervisor.getMagicWindowType(info.packageName, info.name);
+                } else {
+                    type = mTaskSupervisor.getMagicWindowType(r.intent.getComponent().getPackageName(), r.intent.getComponent().flattenToShortString());
+                }
+            }
+        }
+            // fde end
         if (this.intent == null) {
             updateIdentity = true;
         } else if (!mNeverRelinquishIdentity) {
@@ -3546,6 +3566,7 @@ class Task extends TaskFragment {
                 : stripExtras ? baseIntent.cloneFilter() : new Intent(baseIntent);
         info.baseIntent.setFlags(baseIntentFlags);
 
+        info.magicWindowType = type;
         info.isRunning = top != null;
         info.topActivity = top != null ? top.mActivityComponent : null;
         info.origActivity = origActivity;
@@ -4023,6 +4044,8 @@ class Task extends TaskFragment {
         sb.append(Integer.toHexString(System.identityHashCode(this)));
         sb.append(" #");
         sb.append(mTaskId);
+        sb.append(" type=" + type);
+        sb.append(" mWindowLayoutAffinity=" + mWindowLayoutAffinity);
         sb.append(" type=" + activityTypeToString(getActivityType()));
         if (affinity != null) {
             sb.append(" A=");

--- a/services/core/java/com/android/server/wm/TaskDisplayArea.java
+++ b/services/core/java/com/android/server/wm/TaskDisplayArea.java
@@ -35,6 +35,9 @@ import static com.android.server.wm.ActivityTaskManagerService.TAG_ROOT_TASK;
 import static com.android.server.wm.DisplayContent.alwaysCreateRootTask;
 import static com.android.server.wm.WindowManagerDebugConfig.DEBUG_ROOT_TASK;
 import static com.android.server.wm.WindowManagerDebugConfig.TAG_WM;
+import static com.android.server.wm.Task.NOT_MAGIC_WINDOW;
+import static com.android.server.wm.Task.MAGIC_MAIN_WINDOW;
+import static com.android.server.wm.Task.MAGIC_ADDITIONAL_WINDOW;
 
 import android.annotation.ColorInt;
 import android.annotation.Nullable;
@@ -712,12 +715,40 @@ final class TaskDisplayArea extends DisplayArea<WindowContainer> {
             }
         }
 
+        // fde start MAGIC WINDOW
+        recheckStackOrdering();
+        // fde end
+
         int layer = 0;
         // Place root home tasks to the bottom.
         layer = adjustRootTaskLayer(t, mTmpHomeChildren, layer);
         layer = adjustRootTaskLayer(t, mTmpNormalChildren, layer);
         adjustRootTaskLayer(t, mTmpAlwaysOnTopChildren, layer);
     }
+
+    // fde start MAGIC WINDOW
+    // reorder if magic window on top
+    private void recheckStackOrdering() {
+        int size = mTmpNormalChildren.size();
+        if(size == 0 ){
+            return;
+        }
+        WindowContainer topWindow = mTmpNormalChildren.get(size - 1);
+        Task topTask = topWindow.asTask();
+
+        if( topTask != null && (topTask.type == MAGIC_MAIN_WINDOW
+                || topTask.type == MAGIC_ADDITIONAL_WINDOW)){
+            Task magicTask = mRootWindowContainer.findMagicTask(topTask.mWindowLayoutAffinity,
+                    topTask.type == MAGIC_MAIN_WINDOW ? MAGIC_ADDITIONAL_WINDOW : MAGIC_MAIN_WINDOW);
+            if(mTmpNormalChildren.contains(magicTask)){
+                mTmpNormalChildren.remove(magicTask);
+                mTmpNormalChildren.remove(topTask);
+                mTmpNormalChildren.add(magicTask);
+                mTmpNormalChildren.add(topTask);
+            }
+        }
+    }
+    // fde end
 
     /**
      * Adjusts the layer of the root task which belongs to the same group.

--- a/services/core/java/com/android/server/wm/TaskLaunchParamsModifier.java
+++ b/services/core/java/com/android/server/wm/TaskLaunchParamsModifier.java
@@ -40,6 +40,10 @@ import static android.window.DisplayAreaOrganizer.FEATURE_UNDEFINED;
 import static com.android.server.wm.ActivityStarter.Request;
 import static com.android.server.wm.ActivityTaskManagerDebugConfig.TAG_ATM;
 import static com.android.server.wm.ActivityTaskManagerDebugConfig.TAG_WITH_CLASS_NAME;
+import static com.android.server.wm.Task.NOT_MAGIC_WINDOW;
+import static com.android.server.wm.Task.MAGIC_MAIN_WINDOW;
+import static com.android.server.wm.Task.MAGIC_ADDITIONAL_WINDOW;
+import android.text.TextUtils;
 
 import android.annotation.NonNull;
 import android.annotation.Nullable;
@@ -117,6 +121,33 @@ class TaskLaunchParamsModifier implements LaunchParamsModifier {
         } else {
             root = activity;
         }
+
+        // fde start MAGIC WINDOW
+        // magic window additional task will show in right side of main window task, use width when first lunch.
+        if( task != null && task.type == MAGIC_ADDITIONAL_WINDOW && source == null){
+            Task mainTask = mSupervisor.mRootWindowContainer.findMagicTask(task.mWindowLayoutAffinity, MAGIC_MAIN_WINDOW);
+            if(mainTask != null){
+                source = mainTask.topRunningActivity();
+            }
+        }
+        if(task != null && task.type == MAGIC_ADDITIONAL_WINDOW && source != null
+                && source.getTask() != null
+                && TextUtils.equals(source.getTask().mWindowLayoutAffinity, task.mWindowLayoutAffinity)
+                && source.getTask().type == MAGIC_MAIN_WINDOW) {
+            Rect rect = new Rect(source.getConfiguration().windowConfiguration.getBounds());
+            Rect persistRect = currentParams.mBounds;
+            int additionalWidth = currentParams.mAdditionalMagicWindowWidth;
+            if(rect != null ){
+                if(additionalWidth != 0){
+                    rect.set(rect.right, rect.top, rect.right + additionalWidth, rect.bottom);
+                } else {
+                    rect.offset(rect.right - rect.left, 0);
+                }
+                outParams.mBounds.set(rect);
+                return RESULT_CONTINUE;
+            }
+        }
+        // fde end
 
         if (root == null && phase != PHASE_DISPLAY) {
             // There is a case that can lead us here. The caller is moving the top activity that is

--- a/services/core/java/com/android/server/wm/TaskOrganizerController.java
+++ b/services/core/java/com/android/server/wm/TaskOrganizerController.java
@@ -293,6 +293,9 @@ class TaskOrganizerController extends ITaskOrganizerController.Stub {
             }
             mTmpTaskInfo.configuration.unset();
             task.fillTaskInfo(mTmpTaskInfo);
+            if(mTmpTaskInfo == null){
+                return;
+            }
 
             boolean changed = !mTmpTaskInfo
                     .equalsForTaskOrganizer(lastInfo)

--- a/services/core/java/com/android/server/wm/WindowContainer.java
+++ b/services/core/java/com/android/server/wm/WindowContainer.java
@@ -2224,20 +2224,20 @@ class WindowContainer<E extends WindowContainer> extends ConfigurationContainer<
         }
     }
 
-    Task getTaskAbove(Task t) {
+    public Task getTaskAbove(Task t) {
         return getTask(
                 (above) -> true, t, false /*includeBoundary*/, false /*traverseTopToBottom*/);
     }
 
-    Task getTaskBelow(Task t) {
+    public Task getTaskBelow(Task t) {
         return getTask((below) -> true, t, false /*includeBoundary*/, true /*traverseTopToBottom*/);
     }
 
-    Task getBottomMostTask() {
+    public Task getBottomMostTask() {
         return getTask((t) -> true, false /*traverseTopToBottom*/);
     }
 
-    Task getTopMostTask() {
+    public Task getTopMostTask() {
         return getTask((t) -> true, true /*traverseTopToBottom*/);
     }
 

--- a/services/core/java/com/android/server/wm/WindowOrganizerController.java
+++ b/services/core/java/com/android/server/wm/WindowOrganizerController.java
@@ -76,7 +76,10 @@ import static com.android.server.wm.TaskFragment.EMBEDDING_ALLOWED;
 import static com.android.server.wm.TaskFragment.FLAG_FORCE_HIDDEN_FOR_TASK_FRAGMENT_ORG;
 import static com.android.server.wm.WindowContainer.POSITION_BOTTOM;
 import static com.android.server.wm.WindowContainer.POSITION_TOP;
-
+import static com.android.server.wm.Task.NOT_MAGIC_WINDOW;
+import static com.android.server.wm.Task.MAGIC_MAIN_WINDOW;
+import static com.android.server.wm.Task.MAGIC_ADDITIONAL_WINDOW;
+import android.text.TextUtils;
 import android.annotation.NonNull;
 import android.annotation.Nullable;
 import android.app.ActivityManager;
@@ -117,6 +120,7 @@ import android.window.TaskFragmentOperation;
 import android.window.TaskFragmentOrganizerToken;
 import android.window.WindowContainerToken;
 import android.window.WindowContainerTransaction;
+import java.util.Set;
 
 import com.android.internal.annotations.VisibleForTesting;
 import com.android.internal.protolog.ProtoLogGroup;


### PR DESCRIPTION
…move/resize

- Support launching, resizing, moving (to front/back), minimizing, and closing both main and adjoint tasks
- Add MAGIC_ADDITIONAL_WINDOW activity handling, persistence of window width, and task reordering
- Integrate magic window type into TaskInfo and WindowOrganizerController
- Apply transaction logic with detailed logging and build fixes
- Introduce CompatibleConfig and ADDITIONAL_WINDOW_ACTIVITY_LIMIT
- Load configuration from ~/.local/share/openfde/system/magicwindow_config/config.xml (falls back to /system/magicwindow_config/; absence disables feature)
- Enable FDE11-style dual-task display similar to Huawei/Xiaomi, with synchronized move/resize