### PR TITLE
opt caption window would cover app window content

### DIFF
--- a/core/java/com/android/internal/policy/PhoneWindow.java
+++ b/core/java/com/android/internal/policy/PhoneWindow.java
@@ -2838,9 +2838,7 @@ public class PhoneWindow extends Window implements MenuBuilder.Callback {
             // [openfde add] fix caption window would cover app window content
             WindowManager.LayoutParams params = getAttributes();
             int features = getLocalFeatures();
-            if (((params.flags & FLAG_FULLSCREEN) != 0
-                        && (features & (1 << FEATURE_NO_TITLE)) != 0
-                        && (features & (1 << FEATURE_CUSTOM_TITLE)) != 0)
+            if (((params.flags & FLAG_FULLSCREEN) == 0 || (features & (1 << FEATURE_NO_TITLE)) == 0)
                     || (params.compatibleFlags & COMPATIBLE_FLAG_SHIFT_CONTENT_BELOW_CAPTION) != 0
                     || getContext().getPackageName().contains("com.android.launcher3")) {
                 // Set up decor part of UI to ignore fitsSystemWindows if appropriate.


### PR DESCRIPTION
优化标题栏遮挡应用界面的问题

只有当应用申请全屏显示且隐藏标题栏时，才会跳过PFLAG4_FRAMEWORK_OPTIONAL_FITS_SYSTEM_WINDOWS属性的设置

自测大部分游戏应用均为全屏显示，故不再出现遮挡问题，同时不会影响其他应用出现内容下移的问题