### PR TITLE
fix caption window cover app content when enable ShiftContentBelowCaption

### DIFF
--- a/core/java/android/view/WindowLayout.java
+++ b/core/java/android/view/WindowLayout.java
@@ -103,20 +103,14 @@ public class WindowLayout {
             }else{
                 if(outDisplayFrame.top == 0){
                     if(statusBarInsets.top != 0){
-                        if(captionBarInsets.top != 0){
-                            outDisplayFrame.top = captionBarInsets.top + 28;
-                            outParentFrame.top = captionBarInsets.top + 28;
-                            outFrame.top = captionBarInsets.top + 28;
-                        }else{
-                            outDisplayFrame.top = 70;
-                            outParentFrame.top = 70;
-                            outFrame.top = 70;
-                        }
+                        outDisplayFrame.top = captionBarInsets.top + statusBarInsets.top;
+                        outParentFrame.top = captionBarInsets.top + statusBarInsets.top;
+                        outFrame.top = captionBarInsets.top + statusBarInsets.top;
                     }
                 }else{
-                    outDisplayFrame.top += 42;
-                    outParentFrame.top += 42;
-                    outFrame.top += 42;
+                    outDisplayFrame.top += captionBarInsets.top;
+                    outParentFrame.top += captionBarInsets.top;
+                    outFrame.top += captionBarInsets.top;
                 }
             }
             if(DEBUG){


### PR DESCRIPTION
解决D3000M上王者荣耀等应用打开兼容性-标题栏遮挡后，还会出现标题栏遮挡一部分应用内容的问题

解决方案：在不同分辨率场景下，状态栏高度和标题栏高度可能不一致，故修改成从WindowInsets处获取的高度值进行设置
