### PR TITLE
fix Screen Recorder cant record full screen

### DIFF
--- a/services/core/java/com/android/server/wm/ContentRecorder.java
+++ b/services/core/java/com/android/server/wm/ContentRecorder.java
@@ -590,7 +590,7 @@ final class ContentRecorder implements WindowContainerListener {
                 .setWindowCrop(mRecordedSurface, recordedContentBounds)
                 // Scale the root mirror SurfaceControl, based upon the size difference between the
                 // source (DisplayArea to capture) and output (surface the app reads images from).
-                .setMatrix(mRecordedSurface, scale.x, 0 /* dtdx */, 0 /* dtdy */, scale.y)
+                .setMatrix(mRecordedSurface, 1, 0 /* dtdx */, 0 /* dtdy */, 1)
                 // Position needs to be updated when the mirrored DisplayArea has changed, since
                 // the content will no longer be centered in the output surface.
                 .setPosition(mRecordedSurface, shiftedX /* x */, shiftedY /* y */);


### PR DESCRIPTION
解决d3000m上录屏时只能录制部分区域的问题

原因：DisplayContent.getConfiguration().screenWidthDp的值与屏幕密度有关，导致在d3000m上会计算出一个缩放比例为1.6，从而把这个缩放比例传给了录屏的图层，所以出现录制区域不够的问题

解决方案：目前不管是全屏录制还是单个应用录制，设置画布的大小均是直接录制的完整屏幕大小，所以无需再进行scale了 