### PR TITLE
fix incorrect recording area for a single application

### DIFF
--- a/core/api/current.txt
+++ b/core/api/current.txt
@@ -52283,6 +52283,7 @@ package android.view {
     method @FlaggedApi("com.android.window.flags.sdk_desired_present_time") @NonNull public android.view.SurfaceControl.Transaction setFrameTimeline(long);
     method @Deprecated @NonNull public android.view.SurfaceControl.Transaction setGeometry(@NonNull android.view.SurfaceControl, @Nullable android.graphics.Rect, @Nullable android.graphics.Rect, int);
     method @NonNull public android.view.SurfaceControl.Transaction setLayer(@NonNull android.view.SurfaceControl, @IntRange(from=java.lang.Integer.MIN_VALUE, to=java.lang.Integer.MAX_VALUE) int);
+    method public android.view.SurfaceControl.Transaction setMirrorPosition(@NonNull android.view.SurfaceControl, float, float);
     method @NonNull public android.view.SurfaceControl.Transaction setOpaque(@NonNull android.view.SurfaceControl, boolean);
     method @NonNull public android.view.SurfaceControl.Transaction setPosition(@NonNull android.view.SurfaceControl, float, float);
     method @NonNull public android.view.SurfaceControl.Transaction setScale(@NonNull android.view.SurfaceControl, float, float);

--- a/core/api/lint-baseline.txt
+++ b/core/api/lint-baseline.txt
@@ -403,6 +403,10 @@ KotlinOperator: android.graphics.Matrix44#set(int, int, float):
     Method can be invoked with an indexing operator from Kotlin: `set` (this is usually desirable; just make sure it makes sense for this type of object)
 
 
+MissingNullability: android.view.SurfaceControl.Transaction#setMirrorPosition(android.view.SurfaceControl, float, float):
+    Missing nullability on method `setMirrorPosition` return
+
+
 RequiresPermission: android.accounts.AccountManager#getAccountsByTypeAndFeatures(String, String[], android.accounts.AccountManagerCallback<android.accounts.Account[]>, android.os.Handler):
     Method 'getAccountsByTypeAndFeatures' documentation mentions permissions without declaring @RequiresPermission
 RequiresPermission: android.accounts.AccountManager#hasFeatures(android.accounts.Account, String[], android.accounts.AccountManagerCallback<java.lang.Boolean>, android.os.Handler):
@@ -1461,7 +1465,6 @@ UnflaggedApi: android.graphics.text.PositionedGlyphs#getItalicOverride(int):
     New API must be flagged with @FlaggedApi: method android.graphics.text.PositionedGlyphs.getItalicOverride(int)
 UnflaggedApi: android.graphics.text.PositionedGlyphs#getWeightOverride(int):
     New API must be flagged with @FlaggedApi: method android.graphics.text.PositionedGlyphs.getWeightOverride(int)
-
 UnflaggedApi: android.hardware.camera2.ExtensionCaptureRequest:
     New API must be flagged with @FlaggedApi: class android.hardware.camera2.ExtensionCaptureRequest
 UnflaggedApi: android.hardware.camera2.ExtensionCaptureRequest#ExtensionCaptureRequest():
@@ -1574,6 +1577,8 @@ UnflaggedApi: android.view.ScrollFeedbackProvider#onScrollProgress(int, int, int
     New API must be flagged with @FlaggedApi: method android.view.ScrollFeedbackProvider.onScrollProgress(int,int,int,int)
 UnflaggedApi: android.view.ScrollFeedbackProvider#onSnapToItem(int, int, int):
     New API must be flagged with @FlaggedApi: method android.view.ScrollFeedbackProvider.onSnapToItem(int,int,int)
+UnflaggedApi: android.view.SurfaceControl.Transaction#setMirrorPosition(android.view.SurfaceControl, float, float):
+    New API must be flagged with @FlaggedApi: method android.view.SurfaceControl.Transaction.setMirrorPosition(android.view.SurfaceControl,float,float)
 UnflaggedApi: android.view.accessibility.AccessibilityNodeInfo#ACTION_ARGUMENT_SCROLL_AMOUNT_FLOAT:
     New API must be flagged with @FlaggedApi: field android.view.accessibility.AccessibilityNodeInfo.ACTION_ARGUMENT_SCROLL_AMOUNT_FLOAT
 UnflaggedApi: android.view.accessibility.AccessibilityNodeInfo#isGranularScrollingSupported():

--- a/core/java/android/view/SurfaceControl.java
+++ b/core/java/android/view/SurfaceControl.java
@@ -131,6 +131,8 @@ public final class SurfaceControl implements Parcelable {
             long relativeToObject, int zorder);
     private static native void nativeSetPosition(long transactionObj, long nativeObject,
             float x, float y);
+    private static native void nativeSetMirrorPosition(long transactionObj, long nativeObject,
+            float x, float y);
     private static native void nativeSetScale(long transactionObj, long nativeObject,
             float x, float y);
     private static native void nativeSetTransparentRegionHint(long transactionObj,
@@ -2947,6 +2949,16 @@ public final class SurfaceControl implements Parcelable {
                         "setPosition", this, sc, "x=" + x + " y=" + y);
             }
             nativeSetPosition(mNativeObject, sc.mNativeObject, x, y);
+            return this;
+        }
+
+        public Transaction setMirrorPosition(@NonNull SurfaceControl sc, float x, float y) {
+            checkPreconditions(sc);
+            if (SurfaceControlRegistry.sCallStackDebuggingEnabled) {
+                SurfaceControlRegistry.getProcessInstance().checkCallStackDebugging(
+                        "setMirrorPosition", this, sc, "x=" + x + " y=" + y);
+            }
+            nativeSetMirrorPosition(mNativeObject, sc.mNativeObject, x, y);
             return this;
         }
 

--- a/core/jni/android_view_SurfaceControl.cpp
+++ b/core/jni/android_view_SurfaceControl.cpp
@@ -588,6 +588,14 @@ static void nativeSetPosition(JNIEnv* env, jclass clazz, jlong transactionObj,
     transaction->setPosition(ctrl, x, y);
 }
 
+static void nativeSetMirrorPosition(JNIEnv* env, jclass clazz, jlong transactionObj,
+        jlong nativeObject, jfloat x, jfloat y) {
+    auto transaction = reinterpret_cast<SurfaceComposerClient::Transaction*>(transactionObj);
+
+    SurfaceControl* const ctrl = reinterpret_cast<SurfaceControl *>(nativeObject);
+    transaction->setMirrorPosition(ctrl, x, y);
+}
+
 static void nativeSetScale(JNIEnv* env, jclass clazz, jlong transactionObj, jlong nativeObject,
                            jfloat xScale, jfloat yScale) {
     auto transaction = reinterpret_cast<SurfaceComposerClient::Transaction*>(transactionObj);
@@ -2226,6 +2234,8 @@ static const JNINativeMethod sSurfaceControlMethods[] = {
             (void*)nativeSetRelativeLayer },
     {"nativeSetPosition", "(JJFF)V",
             (void*)nativeSetPosition },
+    {"nativeSetMirrorPosition", "(JJFF)V",
+            (void*)nativeSetMirrorPosition },
     {"nativeSetScale", "(JJFF)V",
             (void*)nativeSetScale },
     {"nativeSetTransparentRegionHint", "(JJLandroid/graphics/Region;)V",

--- a/services/core/java/com/android/server/wm/ContentRecorder.java
+++ b/services/core/java/com/android/server/wm/ContentRecorder.java
@@ -544,25 +544,15 @@ final class ContentRecorder implements WindowContainerListener {
         DisplayInfo inputDisplayInfo = mRecordedWindowContainer.mDisplayContent.getDisplayInfo();
         DisplayInfo outputDisplayInfo = mDisplayContent.getDisplayInfo();
 
-        // [openfde add] fix scrcpy window display is too small
-        int screenWidth = mDisplayContent.getConfiguration().screenWidthDp;
-        int screenHeight = mDisplayContent.getConfiguration().screenHeightDp;
-        if (screenWidth > mDisplayContent.getDisplayMetrics().widthPixels
-                || screenHeight > mDisplayContent.getDisplayMetrics().heightPixels) {
-            screenWidth = recordedContentBounds.width();
-            screenHeight = recordedContentBounds.height();
-        }
-        // [openfde end]
-
         PointF scale = new PointF();
-        computeScaling(screenWidth,screenHeight,
+        computeScaling(recordedContentBounds.width(), recordedContentBounds.height(),
                 inputDisplayInfo.physicalXDpi, inputDisplayInfo.physicalYDpi,
                 surfaceSize.x, surfaceSize.y,
                 outputDisplayInfo.physicalXDpi, outputDisplayInfo.physicalYDpi,
                 scale);
 
-        int scaledWidth = Math.round(scale.x * (float) screenWidth);
-        int scaledHeight = Math.round(scale.y * (float) screenHeight);
+        int scaledWidth = Math.round(scale.x * (float) recordedContentBounds.width());
+        int scaledHeight = Math.round(scale.y * (float) recordedContentBounds.height());
 
         // Calculate the shift to apply to the root mirror SurfaceControl to centre the mirrored
         // contents in the output surface.
@@ -584,16 +574,21 @@ final class ContentRecorder implements WindowContainerListener {
                 mDisplayContent.getConfiguration().screenWidthDp,
                 mDisplayContent.getConfiguration().screenHeightDp, surfaceSize.x, surfaceSize.y);
 
+        float recordTransformTx = shiftedX - (recordedContentBounds.left * scale.x);
+        float recordTransformTy = shiftedY - (recordedContentBounds.top * scale.y);
+
         transaction
                 // Crop the area to capture to exclude the 'extra' wallpaper that is used
                 // for parallax (b/189930234).
                 .setWindowCrop(mRecordedSurface, recordedContentBounds)
                 // Scale the root mirror SurfaceControl, based upon the size difference between the
                 // source (DisplayArea to capture) and output (surface the app reads images from).
-                .setMatrix(mRecordedSurface, 1, 0 /* dtdx */, 0 /* dtdy */, 1)
+                .setMatrix(mRecordedSurface, scale.x, 0 /* dtdx */, 0 /* dtdy */, scale.y)
                 // Position needs to be updated when the mirrored DisplayArea has changed, since
                 // the content will no longer be centered in the output surface.
-                .setPosition(mRecordedSurface, shiftedX /* x */, shiftedY /* y */);
+                .setPosition(mRecordedSurface, shiftedX /* x */, shiftedY /* y */)
+                // Mirror Layer Position needs to be updated
+                .setMirrorPosition(mRecordedSurface, recordTransformTx, recordTransformTy);
         mLastRecordedBounds = new Rect(recordedContentBounds);
         mLastConsumingSurfaceSize.x = surfaceSize.x;
         mLastConsumingSurfaceSize.y = surfaceSize.y;


### PR DESCRIPTION
回退之前单应用录屏逻辑，逻辑与原生Android保持一致

解决单应用录屏时，录制区域未正确匹配到应用窗口位置的问题

增加SurfaceControl.Transaction.setMirrorPosition接口，把缩放之后的偏移位置传递给sf，更新mirrorLayer图层的geomLayerTransform属性