### PR TITLE
Fix failure in single-app screen recording

### DIFF
--- a/services/core/java/com/android/server/wm/ActivityMetricsLogger.java
+++ b/services/core/java/com/android/server/wm/ActivityMetricsLogger.java
@@ -416,6 +416,10 @@ class ActivityMetricsLogger {
                 if (lastTask == currentTask) {
                     return true;
                 }
+                if (lastTask.getBounds().width() == currentTask.getBounds().width() &&
+                        lastTask.getBounds().height() == currentTask.getBounds().height()) {
+                    return true;
+                }
                 return lastTask.getBounds().equals(currentTask.getBounds());
             }
             return mLastLaunchedActivity.isUid(r.launchedFromUid);


### PR DESCRIPTION
Analysis of the screen recording process: After selecting the app, it's launched with a launchcookie. Once the app starts, a Virtual Display mirror is created to match the app window, and then the Virtual Display's image is saved. The failure occurred when creating the Virtual Display.

Taking DocumentUI as an example: During launch, two ActivityRecords (LauncherActivity and FilesActivity) are involved. The first ActivityRecord obtains the launchcookie. In the problematic scenario, the window bounds coordinates shift/jump to the right. Under the original condition, the launchcookie would not be passed to the second ActivityRecord via window transition TransitionInfo, causing the system to fail matching the launchcookie to the ActivityRecord, and thus the Virtual Display creation fails. By relaxing the matching condition—now matching windows when package name and dimensions are the same—the issue is resolved.