### PR TITLE
fix android cursor shape not updating correctly

### DIFF
--- a/core/java/android/view/ViewRootImpl.java
+++ b/core/java/android/view/ViewRootImpl.java
@@ -7771,9 +7771,11 @@ public final class ViewRootImpl implements ViewParent,
             mPointerIconType = pointerType;
             mCustomPointerIcon = null;
             if (mPointerIconType != PointerIcon.TYPE_CUSTOM) {
-                InputManagerGlobal
+                mHandler.postDelayed(() -> {
+                    InputManagerGlobal
                         .getInstance()
                         .setPointerIconType(pointerType);
+                }, 8);//The update occurs after the shell, thus increasing the delay.
                 return true;
             }
         }

--- a/core/java/android/view/ViewRootImpl.java
+++ b/core/java/android/view/ViewRootImpl.java
@@ -7775,7 +7775,7 @@ public final class ViewRootImpl implements ViewParent,
                     InputManagerGlobal
                         .getInstance()
                         .setPointerIconType(pointerType);
-                }, 8);//The update occurs after the shell, thus increasing the delay.
+                }, 50);//The update occurs after the shell, thus increasing the delay.
                 return true;
             }
         }


### PR DESCRIPTION
修复Shell模块（systemui进程）与应用进程之间更新光标的并发执行导致Android光标未正确更新的问题，将应用进程的ViewRootImpl延迟8毫秒更新光标，让应用进程在Shell模块更新之后再更新。