### PR TITLE
add GRALLOC_USAGE_PRIVATE_0 usage for rgb565 in mesa env

### DIFF
--- a/libs/hwui/DeferredLayerUpdater.cpp
+++ b/libs/hwui/DeferredLayerUpdater.cpp
@@ -253,7 +253,8 @@ void DeferredLayerUpdater::apply() {
                             int height = graphicBuffer->getHeight();
                             dst_gb = new GraphicBuffer(
                                     width, height, HAL_PIXEL_FORMAT_RGB_565,
-                                    GRALLOC_USAGE_HW_TEXTURE | GRALLOC_USAGE_HW_RENDER);
+                                    GRALLOC_USAGE_HW_TEXTURE | GRALLOC_USAGE_HW_RENDER
+                                        | GRALLOC_USAGE_PRIVATE_0);
 
                             void* dst_data = nullptr;
                             int dst_result = dst_gb->lock(GRALLOC_USAGE_SW_READ_OFTEN | GRALLOC_USAGE_SW_WRITE_OFTEN, &dst_data);


### PR DESCRIPTION
解决爱奇艺播放视频时偶现花屏的问题
-- 爱奇艺视频使用RGB565格式，之前使用YV12格式转RGB565时，要求对rgb进行256位对齐，而stride要求使用原始width*2，否则合成后显示会异常，爱奇艺解码数据无需转换，故stride无需处理
-- 在YV12转RGB565函数中，对RGB565格式新增GRALLOC_USAGE_PRIVATE_0的usage，gbm对该标志位做甄别处理