### PR TITLE
restriction velocitytracker when axis converting touch

### DIFF
--- a/core/jni/android_view_VelocityTracker.cpp
+++ b/core/jni/android_view_VelocityTracker.cpp
@@ -70,6 +70,15 @@ float VelocityTrackerState::getVelocity(int32_t axis, int32_t id) {
         id = mVelocityTracker.getActivePointerId();
     }
 
+    if(property_get_bool("fde.axis_converting_touch", false)){
+        if(mComputedVelocity.getVelocity(axis, id).value_or(0) > 0){
+            return 1.0f;
+        }
+        if(mComputedVelocity.getVelocity(axis, id).value_or(0) < 0){
+            return -1.0f;
+        }
+        return 0.0f;
+    }
     return mComputedVelocity.getVelocity(axis, id).value_or(0);
 }
 


### PR DESCRIPTION
优化在CSDN博文详情页面使用滚轮模拟触摸上下滑动时快时慢的问题。
当滚轴转换触摸时，UI组件获取滑动惯性时，限制滑动速度跟踪器的返回值。