### PR TITLE
Parallel World: fix captionwindow displayed too short

### DIFF
--- a/libs/WindowManager/Shell/src/com/android/wm/shell/windowdecor/CaptionWindowDecorViewModel.java
+++ b/libs/WindowManager/Shell/src/com/android/wm/shell/windowdecor/CaptionWindowDecorViewModel.java
@@ -78,6 +78,7 @@ public class CaptionWindowDecorViewModel implements WindowDecorViewModel {
     private IStatusBarService mBarService;
     private ITaskCaptionOperationService.Stub mTaskCaptionOperationService;
     private static final long RELAYOUT_DELAY = 200;
+    private static final long RELAYOUT_DELAY_500MS = 500;
 
     private final SparseArray<IAppSystemBarController> mAppSystemBarControllers = new SparseArray<>();
     private final SparseArray<CaptionWindowDecoration> mWindowDecorByTaskId = new SparseArray<>();
@@ -243,7 +244,7 @@ public class CaptionWindowDecorViewModel implements WindowDecorViewModel {
         Log.d(TAG, "onTaskInfoChanged taskInfo: " + taskInfo);
         if (taskInfo.isFocused) {
             mRunningTaskId = taskInfo.taskId;
-            updateWindowDecorationDelay(RELAYOUT_DELAY);
+            updateWindowDecorationDelay(RELAYOUT_DELAY_500MS);
         }
         final CaptionWindowDecoration decoration = mWindowDecorByTaskId.get(taskInfo.taskId);
         if (decoration == null) return;


### PR DESCRIPTION
解决平行视界下标题栏概率性出现显示过短的问题

在平行视界场景下，surfaceflinger会先收到一个应用窗口的刷新请求，然后再收到第二个应用窗口的刷新请求，中间会间隔100ms左右，而在wms的标题栏的onTaskInfoChanged方法中会延时200ms后第二次调用captionview的relayout方法，这个时间点会概率性卡在sf还未接收到第二个应用窗口的刷新请求之前，所以导致标题栏显示异常的情况，针对这种情况，把延时提高到500ms后复测问题不再出现