### PR TITLE
fix tiktok play video abnormality

### DIFF
--- a/libs/hwui/Android.bp
+++ b/libs/hwui/Android.bp
@@ -87,6 +87,7 @@ cc_defaults {
                 "external/skia/src/utils",
                 "external/skia/src/gpu",
                 "external/skia/src/shaders",
+                "frameworks/native/libs/nativewindow/include-private/private",
             ],
         },
         host: {

--- a/libs/hwui/Android.bp
+++ b/libs/hwui/Android.bp
@@ -87,7 +87,6 @@ cc_defaults {
                 "external/skia/src/utils",
                 "external/skia/src/gpu",
                 "external/skia/src/shaders",
-                "frameworks/native/libs/nativewindow/include-private/private",
             ],
         },
         host: {

--- a/libs/hwui/DeferredLayerUpdater.cpp
+++ b/libs/hwui/DeferredLayerUpdater.cpp
@@ -30,9 +30,6 @@
 #include "renderthread/RenderThread.h"
 #include "renderthread/VulkanManager.h"
 
-#include <ui/GraphicBuffer.h>
-#include <android/AHardwareBufferHelpers.h>
-
 using namespace android::uirenderer::renderthread;
 
 namespace android {
@@ -134,79 +131,6 @@ status_t DeferredLayerUpdater::fenceWait(int fence, void* handle) {
     return err;
 }
 
-#define ALIGN_M(value, base) (((value) + ((base)-1)) & ~((base)-1))
-#define YUV_R_COEFF 298
-#define YUV_G_COEFF1 100
-#define YUV_G_COEFF2 208
-#define YUV_B_COEFF 516
-#define YUV_R_V_COEFF 409
-#define YUV_BIAS 128
-void yv12_to_rgb565(const unsigned char* yv12_data, int width, int height, unsigned char* rgb_output) {
-
-    // 计算对齐后的UV宽度
-    int aligned_width = ALIGN_M(width, 256);
-    int aligned_half_width = aligned_width / 2;
-
-    // 获取各个平面指针（YV12格式：Y平面 -> V平面 -> U平面）
-    const uint8_t* y_plane = yv12_data;
-    const uint8_t* v_plane = y_plane + aligned_width * height;
-    const uint8_t* u_plane = v_plane + aligned_half_width * (height / 2);
-
-    // 预计算循环中的常量
-    int aligned_y_stride = aligned_width;
-    int aligned_uv_stride = aligned_half_width;
-
-    // 遍历所有行
-    for (int y = 0; y < height; y++) {
-        // 计算UV行索引
-        int uv_y = y / 2;
-        int uv_row_offset = uv_y * aligned_uv_stride;
-
-        // Y行起始位置
-        const uint8_t* y_row = y_plane + y * aligned_y_stride;
-
-        // RGB行起始位置
-        uint16_t* rgb_row = (uint16_t*)(rgb_output + y * aligned_width * 2);
-
-        int x;
-
-        // 处理有效像素区域 (0 到 width-1)
-        for (x = 0; x < width; x++) {
-            // 计算UV列索引
-            int uv_x = x / 2;
-            int uv_idx = uv_row_offset + uv_x;
-
-            // 获取YUV值
-            int y_val = y_row[x];
-            int u_val = u_plane[uv_idx];
-            int v_val = v_plane[uv_idx];
-
-            // YUV到RGB转换（快速整数算法）
-            int c = y_val - 16;
-            int d = u_val - 128;
-            int e = v_val - 128;
-
-            // 快速转换
-            int r = (YUV_R_COEFF * c + YUV_R_V_COEFF * e + YUV_BIAS) >> 8;
-            int g = (YUV_R_COEFF * c - YUV_G_COEFF1 * d - YUV_G_COEFF2 * e + YUV_BIAS) >> 8;
-            int b = (YUV_R_COEFF * c + YUV_B_COEFF * d + YUV_BIAS) >> 8;
-
-            // 钳位到0-255范围
-            r = (r < 0) ? 0 : ((r > 255) ? 255 : r);
-            g = (g < 0) ? 0 : ((g > 255) ? 255 : g);
-            b = (b < 0) ? 0 : ((b > 255) ? 255 : b);
-
-            // 转换为RGB565并存储
-            rgb_row[x] = ((r >> 3) << 11) | ((g >> 2) << 5) | (b >> 3);
-        }
-
-        // 填充右侧区域 (width 到 aligned_width-1) 为黑色
-        for (; x < aligned_width; x++) {
-            rgb_row[x] = 0x0000;  // RGB565黑色
-        }
-    }
-}
-
 void DeferredLayerUpdater::apply() {
     if (!mLayer) {
         mLayer = new Layer(mRenderState, mColorFilter, mAlpha, mMode);
@@ -241,42 +165,9 @@ void DeferredLayerUpdater::apply() {
                     fenceWait, this, &currentCrop);
 
             if (hardwareBuffer) {
-                sp<GraphicBuffer> dst_gb;
-                sp<GraphicBuffer> graphicBuffer = AHardwareBuffer_to_GraphicBuffer(hardwareBuffer);
-                if (graphicBuffer->getPixelFormat() == HAL_PIXEL_FORMAT_YV12) {
-                    if (graphicBuffer->needCovertFormat()) {
-                        void* data = nullptr;
-                        int result = graphicBuffer->lock(GRALLOC_USAGE_SW_READ_OFTEN, &data);
-                        if (result == 0 && data != nullptr) {
-                            unsigned char* yuv_data = (unsigned char*)data;
-                            int width = graphicBuffer->getWidth();
-                            int height = graphicBuffer->getHeight();
-                            dst_gb = new GraphicBuffer(
-                                    width, height, HAL_PIXEL_FORMAT_RGB_565,
-                                    GRALLOC_USAGE_HW_TEXTURE | GRALLOC_USAGE_HW_RENDER
-                                        | GRALLOC_USAGE_PRIVATE_0);
-
-                            void* dst_data = nullptr;
-                            int dst_result = dst_gb->lock(GRALLOC_USAGE_SW_READ_OFTEN | GRALLOC_USAGE_SW_WRITE_OFTEN, &dst_data);
-                            if (dst_result == 0 && dst_data != nullptr) {
-                                unsigned char* rgb565 = (unsigned char*) dst_data;
-                                yv12_to_rgb565(yuv_data, width, height, rgb565);
-                            }
-                            if (dst_gb != NULL) {
-                                dst_gb->unlock();
-                            }
-                            graphicBuffer->unlock();
-                        }
-                    }
-                }
-                AHardwareBuffer* new_hardwareBuffer = hardwareBuffer;
-                if (dst_gb != NULL) {
-                    new_hardwareBuffer = AHardwareBuffer_from_GraphicBuffer(dst_gb.get());
-                }
-
                 mCurrentSlot = slot;
                 sk_sp<SkImage> layerImage = mImageSlots[slot].createIfNeeded(
-                        new_hardwareBuffer, dataspace, newContent,
+                        hardwareBuffer, dataspace, newContent,
                         mRenderState.getRenderThread().getGrContext());
                 AHardwareBuffer_Desc bufferDesc;
                 AHardwareBuffer_describe(hardwareBuffer, &bufferDesc);

--- a/libs/hwui/DeferredLayerUpdater.cpp
+++ b/libs/hwui/DeferredLayerUpdater.cpp
@@ -30,7 +30,12 @@
 #include "renderthread/RenderThread.h"
 #include "renderthread/VulkanManager.h"
 
+#include <ui/GraphicBuffer.h>
+#include <android/AHardwareBufferHelpers.h>
+
 using namespace android::uirenderer::renderthread;
+
+#define ALIGN_M(value, base) (((value) + ((base)-1)) & ~((base)-1))
 
 namespace android {
 namespace uirenderer {
@@ -131,6 +136,56 @@ status_t DeferredLayerUpdater::fenceWait(int fence, void* handle) {
     return err;
 }
 
+void yv12_to_bgra(const unsigned char* yv12_data, int width, int height, int y_stride,
+                    unsigned char* rgb_output) {
+    int uv_stride = y_stride / 2;
+
+    size_t y_size = y_stride * height;
+    size_t uv_size = uv_stride * (height / 2);
+
+    const uint8_t* y_plane = yv12_data;
+    const uint8_t* v_plane = yv12_data + y_size;
+    const uint8_t* u_plane = v_plane + uv_size;
+
+    const int coef_rv = 359;   // 1.402 * 256
+    const int coef_gu = 88;    // 0.344 * 256
+    const int coef_gv = 183;   // 0.714 * 256
+    const int coef_bu = 454;   // 1.773 * 256
+
+    for (int y = 0; y < height; y++) {
+        const uint8_t* src_y = y_plane + y * y_stride;
+        uint8_t* dst = rgb_output + y * width * 4;
+
+        int uv_y = y / 2;
+        const uint8_t* src_v = v_plane + uv_y * uv_stride;
+        const uint8_t* src_u = u_plane + uv_y * uv_stride;
+
+        for (int x = 0; x < width; x++) {
+            int uv_x = x / 2;
+            int Y = src_y[x];
+            int V = src_v[uv_x];
+            int U = src_u[uv_x];
+
+            int C = Y;
+            int D = U - 128;
+            int E = V - 128;
+
+            int R = (C * 298 + coef_rv * E + 128) >> 8;
+            int G = (C * 298 - coef_gu * D - coef_gv * E + 128) >> 8;
+            int B = (C * 298 + coef_bu * D + 128) >> 8;
+
+            if (R < 0) R = 0; else if (R > 255) R = 255;
+            if (G < 0) G = 0; else if (G > 255) G = 255;
+            if (B < 0) B = 0; else if (B > 255) B = 255;
+
+            dst[4*x + 0] = (uint8_t)B;
+            dst[4*x + 1] = (uint8_t)G;
+            dst[4*x + 2] = (uint8_t)R;
+            dst[4*x + 3] = 0xFF;   // Alpha
+        }
+    }
+}
+
 void DeferredLayerUpdater::apply() {
     if (!mLayer) {
         mLayer = new Layer(mRenderState, mColorFilter, mAlpha, mMode);
@@ -165,9 +220,50 @@ void DeferredLayerUpdater::apply() {
                     fenceWait, this, &currentCrop);
 
             if (hardwareBuffer) {
+                int srcWidth = 0;
+                int srcHeight = 0;
+                sp<GraphicBuffer> dst_gb;
+                sp<GraphicBuffer> graphicBuffer = AHardwareBuffer_to_GraphicBuffer(hardwareBuffer);
+                if (graphicBuffer->getPixelFormat() == HAL_PIXEL_FORMAT_YV12) {
+                    if (graphicBuffer->needConvertFormat()) {
+                        void* data = nullptr;
+                        int result = graphicBuffer->lock(GRALLOC_USAGE_SW_READ_OFTEN, &data);
+                        if (result == 0 && data != nullptr) {
+                            unsigned char* yuv_data = (unsigned char*)data;
+                            int width = graphicBuffer->getWidth();
+                            int height = graphicBuffer->getHeight();
+                            int stride = graphicBuffer->getStride();
+
+                            srcWidth = width;
+                            srcHeight = height;
+                            width = ALIGN_M(width,64);
+
+                            dst_gb = new GraphicBuffer(
+                                    width, height, HAL_PIXEL_FORMAT_BGRA_8888,
+                                    GRALLOC_USAGE_HW_TEXTURE | GRALLOC_USAGE_HW_RENDER
+                                        | GRALLOC_USAGE_PRIVATE_0);
+
+                            void* dst_data = nullptr;
+                            int dst_result = dst_gb->lock(GRALLOC_USAGE_SW_WRITE_OFTEN, &dst_data);
+                            if (dst_result == 0 && dst_data != nullptr) {
+                                unsigned char* bgra = (unsigned char*) dst_data;
+                                yv12_to_bgra(yuv_data, width, height, stride, bgra);
+                            }
+                            if (dst_gb != NULL) {
+                                dst_gb->unlock();
+                            }
+                            graphicBuffer->unlock();
+                        }
+                    }
+                }
+                AHardwareBuffer* new_hardwareBuffer = hardwareBuffer;
+                if (dst_gb != NULL) {
+                    new_hardwareBuffer = AHardwareBuffer_from_GraphicBuffer(dst_gb.get());
+                }
+
                 mCurrentSlot = slot;
                 sk_sp<SkImage> layerImage = mImageSlots[slot].createIfNeeded(
-                        hardwareBuffer, dataspace, newContent,
+                        new_hardwareBuffer, dataspace, newContent,
                         mRenderState.getRenderThread().getGrContext());
                 AHardwareBuffer_Desc bufferDesc;
                 AHardwareBuffer_describe(hardwareBuffer, &bufferDesc);
@@ -178,6 +274,14 @@ void DeferredLayerUpdater::apply() {
                     // force filtration if buffer size != layer size
                     bool forceFilter =
                             mWidth != layerImage->width() || mHeight != layerImage->height();
+                    if (dst_gb != NULL) {
+                        if (dst_gb->getUsage() & GRALLOC_USAGE_PRIVATE_0) {
+                            if (srcWidth != layerImage->width() || srcHeight != layerImage->height()) {
+                                currentCrop.right = srcWidth;
+                                currentCrop.bottom = srcHeight;
+                            }
+                        }
+                    }
                     SkRect currentCropRect =
                             SkRect::MakeLTRB(currentCrop.left, currentCrop.top, currentCrop.right,
                                              currentCrop.bottom);


### PR DESCRIPTION
解决抖音/快手在AMD显卡环境下播放视频花屏等问题

由于AMD显卡环境要求256对齐，故使用BGRA中间层进行一次转换，先把YV12数据转换成BGRA数据，然后再把BGRA数据送至surfaceflinger参与合成显示