### PR TITLE
fix bilibili live yv12 video play abnormality

### DIFF
--- a/core/jni/android_graphics_SurfaceTexture.cpp
+++ b/core/jni/android_graphics_SurfaceTexture.cpp
@@ -27,6 +27,7 @@
 #include <gui/Surface.h>
 #include <nativehelper/JNIHelp.h>
 #include <nativehelper/ScopedLocalRef.h>
+#include <nativehelper/ScopedUtfChars.h>
 #include <stdio.h>
 #include <surfacetexture/SurfaceTexture.h>
 #include <surfacetexture/surface_texture_platform.h>
@@ -311,6 +312,13 @@ static void SurfaceTexture_init(JNIEnv* env, jobject thiz, jboolean isDetached,
     }
 }
 
+static void SurfaceTexture_setPackageName(JNIEnv *env, jobject thiz, jstring opPackageName)
+{
+    sp<SurfaceTexture> surfaceTexture(SurfaceTexture_getSurfaceTexture(env, thiz));
+    ScopedUtfChars opPackageNameUtf(env, opPackageName);
+    surfaceTexture->setPackageName(String8(opPackageNameUtf.c_str()));
+}
+
 static void SurfaceTexture_finalize(JNIEnv* env, jobject thiz)
 {
     sp<SurfaceTexture> surfaceTexture(SurfaceTexture_getSurfaceTexture(env, thiz));
@@ -402,6 +410,7 @@ static jboolean SurfaceTexture_isReleased(JNIEnv* env, jobject thiz)
 
 static const JNINativeMethod gSurfaceTextureMethods[] = {
         {"nativeInit", "(ZIZLjava/lang/ref/WeakReference;)V", (void*)SurfaceTexture_init},
+        {"nativeSetPackageName", "(Ljava/lang/String;)V", (void *)SurfaceTexture_setPackageName},
         {"nativeFinalize", "()V", (void*)SurfaceTexture_finalize},
         {"nativeSetDefaultBufferSize", "(II)V", (void*)SurfaceTexture_setDefaultBufferSize},
         {"nativeUpdateTexImage", "()V", (void*)SurfaceTexture_updateTexImage},

--- a/graphics/java/android/graphics/SurfaceTexture.java
+++ b/graphics/java/android/graphics/SurfaceTexture.java
@@ -19,6 +19,7 @@ package android.graphics;
 import android.annotation.FloatRange;
 import android.annotation.Nullable;
 import android.annotation.SuppressLint;
+import android.app.ActivityThread;
 import android.compat.annotation.UnsupportedAppUsage;
 import android.hardware.DataSpace.NamedDataSpace;
 import android.os.Build;
@@ -166,6 +167,8 @@ public class SurfaceTexture {
         mCreatorLooper = Looper.myLooper();
         mIsSingleBuffered = singleBufferMode;
         nativeInit(false, texName, singleBufferMode, new WeakReference<SurfaceTexture>(this));
+        String packageName = ActivityThread.currentPackageName();
+        nativeSetPackageName(packageName);
     }
 
     /**
@@ -193,6 +196,8 @@ public class SurfaceTexture {
         mCreatorLooper = Looper.myLooper();
         mIsSingleBuffered = singleBufferMode;
         nativeInit(true, 0, singleBufferMode, new WeakReference<SurfaceTexture>(this));
+        String packageName = ActivityThread.currentPackageName();
+        nativeSetPackageName(packageName);
     }
 
     /**
@@ -518,6 +523,7 @@ public class SurfaceTexture {
     private native void nativeInit(boolean isDetached, int texName,
             boolean singleBufferMode, WeakReference<SurfaceTexture> weakSelf)
             throws Surface.OutOfResourcesException;
+    private native void nativeSetPackageName(String packageName);
     private native void nativeFinalize();
     private native void nativeGetTransformMatrix(float[] mtx);
     private native long nativeGetTimestamp();


### PR DESCRIPTION
解决B站应用直播页面下礼物等特效视频显示花屏的问题

1.该特效调用系统H265解码器解码后使用SurfaceTexture直接渲染，故在ST中提取有效画面到BGRA，并使用BGRA数据进行显示
2.由于优酷应用播放视频的通路也走此通路，但优酷无花屏等问题，故此方案仅针对B站应用生效