### PR TITLE
FreeformTaskTransitionObserver: investigate changeCount=0 for slow-st…

### DIFF
--- a/libs/WindowManager/Shell/src/com/android/wm/shell/freeform/FreeformTaskListener.java
+++ b/libs/WindowManager/Shell/src/com/android/wm/shell/freeform/FreeformTaskListener.java
@@ -20,8 +20,9 @@ import static android.app.WindowConfiguration.WINDOWING_MODE_FREEFORM;
 
 import static com.android.wm.shell.ShellTaskOrganizer.TASK_LISTENER_TYPE_FREEFORM;
 
+import android.graphics.Rect;
 import android.app.ActivityManager.RunningTaskInfo;
-import android.util.SparseArray;
+import android.util.Log;
 import android.view.SurfaceControl;
 
 import com.android.internal.protolog.common.ProtoLog;
@@ -35,6 +36,7 @@ import com.android.wm.shell.windowdecor.WindowDecorViewModel;
 
 import java.io.PrintWriter;
 import java.util.Optional;
+import android.util.SparseArray;
 
 /**
  * {@link ShellTaskOrganizer.TaskListener} for {@link
@@ -43,6 +45,22 @@ import java.util.Optional;
 public class FreeformTaskListener implements ShellTaskOrganizer.TaskListener,
         ShellTaskOrganizer.FocusListener {
     private static final String TAG = "FreeformTaskListener";
+
+    private static String formatTaskForLog(RunningTaskInfo taskInfo) {
+        if (taskInfo == null) {
+            return "taskInfo=null";
+        }
+        final String topActivity = taskInfo.topActivity != null
+                ? taskInfo.topActivity.flattenToShortString() : "null";
+        return "taskId=" + taskInfo.taskId
+                + ", windowingMode=" + taskInfo.getWindowingMode()
+                + ", visible=" + taskInfo.isVisible
+                + ", focused=" + taskInfo.isFocused
+                + ", isResizeable=" + taskInfo.isResizeable
+                + ", positionInParent=" + taskInfo.positionInParent
+                + ", bounds=" + taskInfo.configuration.windowConfiguration.getBounds()
+                + ", topActivity=" + topActivity;
+    }
 
     private final ShellTaskOrganizer mShellTaskOrganizer;
     private final Optional<DesktopModeTaskRepository> mDesktopModeTaskRepository;
@@ -75,13 +93,28 @@ public class FreeformTaskListener implements ShellTaskOrganizer.TaskListener,
         }
     }
 
+    private void forceTaskPositionAndCrop(
+            RunningTaskInfo taskInfo, SurfaceControl leash, SurfaceControl.Transaction t) {
+        if (taskInfo == null || leash == null) {
+            return;
+        }
+        final Rect bounds = taskInfo.configuration.windowConfiguration.getBounds();
+        if (bounds == null || bounds.isEmpty()) {
+            Log.d(TAG, "[窗口装饰兜底] forceTaskPositionAndCrop 跳过，原因=bounds 无效，"
+                    + formatTaskForLog(taskInfo));
+            return;
+        }
+        final int width = bounds.width();
+        final int height = bounds.height();
+        t.setWindowCrop(leash, width, height)
+                .setPosition(leash, taskInfo.positionInParent.x, taskInfo.positionInParent.y);
+    }
+
     @Override
     public void onTaskAppeared(RunningTaskInfo taskInfo, SurfaceControl leash) {
         if (mTasks.get(taskInfo.taskId) != null) {
             throw new IllegalStateException("Task appeared more than once: #" + taskInfo.taskId);
         }
-        ProtoLog.v(ShellProtoLogGroup.WM_SHELL_TASK_ORG, "Freeform Task Appeared: #%d",
-                taskInfo.taskId);
         final State state = new State();
         state.mTaskInfo = taskInfo;
         state.mLeash = leash;
@@ -89,6 +122,10 @@ public class FreeformTaskListener implements ShellTaskOrganizer.TaskListener,
         if (!Transitions.ENABLE_SHELL_TRANSITIONS) {
             SurfaceControl.Transaction t = new SurfaceControl.Transaction();
             mWindowDecorationViewModel.onTaskOpening(taskInfo, leash, t, t);
+            t.apply();
+        } else if (leash != null) {
+            SurfaceControl.Transaction t = new SurfaceControl.Transaction();
+            forceTaskPositionAndCrop(taskInfo, leash, t);
             t.apply();
         }
 
@@ -111,6 +148,7 @@ public class FreeformTaskListener implements ShellTaskOrganizer.TaskListener,
     public void onTaskVanished(RunningTaskInfo taskInfo) {
         ProtoLog.v(ShellProtoLogGroup.WM_SHELL_TASK_ORG, "Freeform Task Vanished: #%d",
                 taskInfo.taskId);
+
         mTasks.remove(taskInfo.taskId);
 
         if (DesktopModeStatus.isEnabled()) {
@@ -135,8 +173,31 @@ public class FreeformTaskListener implements ShellTaskOrganizer.TaskListener,
 
         ProtoLog.v(ShellProtoLogGroup.WM_SHELL_TASK_ORG, "Freeform Task Info Changed: #%d",
                 taskInfo.taskId);
-        mWindowDecorationViewModel.onTaskInfoChanged(taskInfo);
-        state.mTaskInfo = taskInfo;
+        if (state == null) {
+            mWindowDecorationViewModel.onTaskInfoChanged(taskInfo);
+        } else {
+            state.mTaskInfo = taskInfo;
+            final boolean needFallbackCreate = Transitions.ENABLE_SHELL_TRANSITIONS
+                    && taskInfo.isVisible
+                    && state.mLeash != null
+                    && !mWindowDecorationViewModel.hasWindowDecor(taskInfo.taskId);
+            if (needFallbackCreate) {
+                SurfaceControl.Transaction t = new SurfaceControl.Transaction();
+                mWindowDecorationViewModel.onTaskOpening(taskInfo, state.mLeash, t, t);
+                mWindowDecorationViewModel.onTaskChanging(taskInfo, state.mLeash, t, t);
+                t.apply();
+            } else {
+                mWindowDecorationViewModel.onTaskInfoChanged(taskInfo);
+                if (Transitions.ENABLE_SHELL_TRANSITIONS
+                        && taskInfo.isVisible
+                        && state.mLeash != null
+                        && mWindowDecorationViewModel.hasWindowDecor(taskInfo.taskId)) {
+                    SurfaceControl.Transaction t = new SurfaceControl.Transaction();
+                    mWindowDecorationViewModel.onTaskChanging(taskInfo, state.mLeash, t, t);
+                    t.apply();
+                }
+            }
+        }
         if (DesktopModeStatus.isEnabled()) {
             mDesktopModeTaskRepository.ifPresent(repository -> {
                 if (taskInfo.isVisible) {
@@ -156,6 +217,7 @@ public class FreeformTaskListener implements ShellTaskOrganizer.TaskListener,
         if (taskInfo.getWindowingMode() != WINDOWING_MODE_FREEFORM) {
             return;
         }
+                + formatTaskForLog(taskInfo));
         ProtoLog.v(ShellProtoLogGroup.WM_SHELL_TASK_ORG,
                 "Freeform Task Focus Changed: #%d focused=%b",
                 taskInfo.taskId, taskInfo.isFocused);

--- a/libs/WindowManager/Shell/src/com/android/wm/shell/freeform/FreeformTaskTransitionObserver.java
+++ b/libs/WindowManager/Shell/src/com/android/wm/shell/freeform/FreeformTaskTransitionObserver.java
@@ -19,7 +19,7 @@ package com.android.wm.shell.freeform;
 import android.app.ActivityManager;
 import android.content.Context;
 import android.os.IBinder;
-import android.view.SurfaceControl;
+import android.util.Log;
 import android.view.WindowManager;
 import android.window.TransitionInfo;
 import android.window.WindowContainerToken;
@@ -36,13 +36,31 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
+import android.view.SurfaceControl;
 /**
  * The {@link Transitions.TransitionHandler} that handles freeform task launches, closes,
  * maximizing and restoring transitions. It also reports transitions so that window decorations can
  * be a part of transitions.
  */
 public class FreeformTaskTransitionObserver implements Transitions.TransitionObserver {
+    private static final String TAG = "FreeformTaskTransitionObserver";
+
+    private static String formatTaskForLog(ActivityManager.RunningTaskInfo taskInfo) {
+        if (taskInfo == null) {
+            return "taskInfo=null";
+        }
+        final String topActivity = taskInfo.topActivity != null
+                ? taskInfo.topActivity.flattenToShortString() : "null";
+        return "taskId=" + taskInfo.taskId
+                + ", windowingMode=" + taskInfo.getWindowingMode()
+                + ", visible=" + taskInfo.isVisible
+                + ", focused=" + taskInfo.isFocused
+                + ", isResizeable=" + taskInfo.isResizeable
+                + ", positionInParent=" + taskInfo.positionInParent
+                + ", bounds=" + taskInfo.configuration.windowConfiguration.getBounds()
+                + ", topActivity=" + topActivity;
+    }
+
     private final Transitions mTransitions;
     private final WindowDecorViewModel mWindowDecorViewModel;
 
@@ -61,6 +79,9 @@ public class FreeformTaskTransitionObserver implements Transitions.TransitionObs
         }
     }
 
+    @Override
+    public void onTransitionStarting(@NonNull IBinder transition) {}
+
     @VisibleForTesting
     void onInit() {
         mTransitions.registerObserver(this);
@@ -75,12 +96,14 @@ public class FreeformTaskTransitionObserver implements Transitions.TransitionObs
         final ArrayList<ActivityManager.RunningTaskInfo> taskInfoList = new ArrayList<>();
         final ArrayList<WindowContainerToken> taskParents = new ArrayList<>();
         for (TransitionInfo.Change change : info.getChanges()) {
+            final ActivityManager.RunningTaskInfo taskInfo = change.getTaskInfo();
             if ((change.getFlags() & TransitionInfo.FLAG_IS_WALLPAPER) != 0) {
+                Log.d(TAG, "[窗口装饰过渡] 跳过 change，原因=FLAG_IS_WALLPAPER");
                 continue;
             }
 
-            final ActivityManager.RunningTaskInfo taskInfo = change.getTaskInfo();
             if (taskInfo == null || taskInfo.taskId == -1) {
+                Log.d(TAG, "[窗口装饰过渡] 跳过 change，原因=taskInfo 为空或 taskId 无效");
                 continue;
             }
             // Filter out non-leaf tasks. Freeform/fullscreen don't nest tasks, but split-screen
@@ -93,6 +116,8 @@ public class FreeformTaskTransitionObserver implements Transitions.TransitionObs
                 taskParents.add(change.getParent());
             }
             if (taskParents.contains(change.getContainer())) {
+                Log.d(TAG, "[窗口装饰过渡] 跳过 change，原因=当前 container 被识别为 parent task，container="
+                        + change.getContainer() + ", " + formatTaskForLog(taskInfo));
                 continue;
             }
 
@@ -110,6 +135,8 @@ public class FreeformTaskTransitionObserver implements Transitions.TransitionObs
                 }
                 case WindowManager.TRANSIT_CHANGE:
                     onChangeTransitionReady(change, startT, finishT);
+                    break;
+                default:
                     break;
             }
         }
@@ -146,9 +173,6 @@ public class FreeformTaskTransitionObserver implements Transitions.TransitionObs
         mWindowDecorViewModel.onTaskChanging(
                 change.getTaskInfo(), change.getLeash(), startT, finishT);
     }
-
-    @Override
-    public void onTransitionStarting(@NonNull IBinder transition) {}
 
     @Override
     public void onTransitionMerged(@NonNull IBinder merged, @NonNull IBinder playing) {

--- a/libs/WindowManager/Shell/src/com/android/wm/shell/windowdecor/CaptionWindowDecorViewModel.java
+++ b/libs/WindowManager/Shell/src/com/android/wm/shell/windowdecor/CaptionWindowDecorViewModel.java
@@ -324,7 +324,7 @@ public class CaptionWindowDecorViewModel implements WindowDecorViewModel {
             createWindowDecoration(taskInfo, taskSurface, startT, finishT);
         } else {
             decoration.relayout(taskInfo, startT, finishT, false /* applyStartTransactionOnDraw */,
-                    false /* setTaskCropAndPosition */);
+                    true /* setTaskCropAndPosition */);
         }
     }
 
@@ -339,7 +339,7 @@ public class CaptionWindowDecorViewModel implements WindowDecorViewModel {
         if (decoration == null) return;
 
         decoration.relayout(taskInfo, startT, finishT, false /* applyStartTransactionOnDraw */,
-                false /* setTaskCropAndPosition */);
+                true /* setTaskCropAndPosition */);
     }
 
     @Override


### PR DESCRIPTION
…arting apps

Root cause: when an app's cold start exceeds BLAST_TIMEOUT_DURATION (5000ms), the sync engine forces the transition to proceed via onTransactionReady() before the activity becomes visible. At that point, ChangeInfo.hasChanged() returns false (stayInvisible) because both currVisible and mVisible are false. This results in calculateTargets() returning an empty list and the TransitionInfo arriving in Shell with changeCount=0, which causes the transition to be aborted immediately and window decorations (title bar) to never be created.

Timeline:
  T+0s    Activity collected into SyncGroup, mVisible=false
  T+5s    BLASTSyncEngine timeout: "Sync group N timeout"
          → onTransactionReady → hasChanged: stayInvisible
          → changeCount=0 → Shell abort → decorations lost
  T+9s    EnsureActivitiesVisibleHelper rescues the activity
          via onVisibleWithoutCollectingTransition()

The app (com.lite.ceclanxin) eventually becomes visible through the fallback path, but SystemUI's freeform title bar lifecycle is already missed.

修复https://github.com/openfde/openfde/issues/382 部分应用概率打开后应用标题栏会被系统状态栏遮挡